### PR TITLE
fix(article): make Read & Words right aside sticky

### DIFF
--- a/docs/bugs/2026-04-30-adjust-left-right-column-ratio.md
+++ b/docs/bugs/2026-04-30-adjust-left-right-column-ratio.md
@@ -1,0 +1,68 @@
+# 2026-04-30 — adjust-left-right-column-ratio
+
+**Severity:** low
+**Area:** website
+**Status:** fixed
+**Keywords:** article, layout, sticky, aside, read-and-words, story-page, scroll, balance
+
+## Symptom
+
+User feedback (issue #6, feedback row 11, user level Tree, en) on
+2026-04-30:
+
+> the story left side is too long comparing to right side. Maybe we
+> can use scroll or adjust the left right ratio to make it more
+> balance and easy to read.
+
+The Read & Words tab of the article view (`ReadAndWordsTab`) renders
+the article body in a left column ("The Story", 250-340 words) next
+to a right `<aside>` containing 3-5 keyword cards plus an optional
+"Why it matters" panel. At desktop widths the body column is 4-6×
+taller than the aside, so once the user scrolls into the body the
+keyword glossary scrolls off-screen and they lose the in-context
+hint cards the design depended on.
+
+## Root cause
+
+`website/article.jsx:530` lays the tab out as
+`gridTemplateColumns: '1.6fr 1fr'`. The right `<aside>` had no
+`position: sticky`, so by default its grid item stretched to the
+row height (`align-self: stretch`) and scrolled with the body.
+Functionally correct but visually unbalanced; the keyword glossary
+is referenced from the highlighted words in the body, but once the
+user is mid-paragraph the glossary is no longer visible.
+
+A nearly identical sticky pattern was already used elsewhere in
+`article.jsx` (line 990, the quiz tab's "Look back at the story"
+panel uses `position:'sticky', top:90, maxHeight:'calc(100vh - 110px)', overflow:'auto'`),
+so the pattern was a known good fit — just hadn't been applied to
+the Read & Words aside.
+
+## Fix
+
+PR: opened against `main` from branch `fix/issue-6-sticky-aside`.
+
+- `website/article.jsx:561` — added `position:'sticky', top:90, alignSelf:'start', maxHeight:'calc(100vh - 110px)', overflow:'auto'` to the `<aside>` style. `alignSelf:'start'` is required so the grid item is content-height (not stretched), otherwise sticky just sits at the top of a full-height cell and never sticks. `top:90` matches the sticky header offset already used at line 990.
+
+## Invariant
+
+In `ReadAndWordsTab`, the right aside MUST stay in view while the
+user scrolls the long body. If a future edit introduces a parent
+container with `overflow: hidden | auto | scroll` between the
+sticky aside and the page viewport, sticky will silently break.
+The aside's grid item must remain content-sized (`align-self: start`
+or equivalent) — switching it back to stretched will also break
+sticky.
+
+## Pinning test
+
+MANUAL: open any article, stay on the default Read & Words tab,
+scroll the page down. The Word Treasure / Why it matters panel
+on the right must remain visible at the top of the viewport while
+the story scrolls. If the right column scrolls away with the body,
+the sticky pattern has regressed.
+
+## Related
+
+- `website/article.jsx:990` — pre-existing sticky pattern (quiz
+  tab's "Look back at the story") that this fix mirrors.

--- a/docs/bugs/INDEX.md
+++ b/docs/bugs/INDEX.md
@@ -16,6 +16,7 @@ you must not break.
 
 | Date | Sev | Area | Record | Symptom | Keywords |
 |---|---|---|---|---|---|
+| 2026-04-30 | low | website | [adjust-left-right-column-ratio](2026-04-30-adjust-left-right-column-ratio.md) | Read & Words tab right aside scrolled away with the long article body, losing the keyword glossary mid-read | article, layout, sticky, aside, read-and-words, scroll, balance |
 | 2026-04-30 | medium | infra | [supabase-edge-fn-html-blocked](2026-04-30-supabase-edge-fn-html-blocked.md) | Supabase Edge Functions silently override Content-Type to text/plain + add sandbox CSP, breaking HTML rendering in browsers | supabase, edge-function, content-type, csp, sandbox, html |
 | 2026-04-29 | medium | infra | [autofix-token-starvation](2026-04-29-autofix-token-starvation.md) | Autofix daemon's back-to-back claude -p calls starved the user's IDE of API quota for ~2 min | claude, headless, daemon, rate-limit, concurrency, autofix |
 | 2026-04-29 | high | website | [search-click-wrong-article](2026-04-29-search-click-wrong-article.md) | Clicking a search hit always opened today's first article instead of the searched one | search, archive, ARTICLES.find, listing-overwrite, synthetic-merge |

--- a/website/article.jsx
+++ b/website/article.jsx
@@ -558,7 +558,7 @@ function ReadAndWordsTab({ article, paragraphs, expanded, setExpanded, onFinish 
         </div>
       </div>
 
-      <aside style={{display:'flex', flexDirection:'column', gap:14}}>
+      <aside style={{display:'flex', flexDirection:'column', gap:14, position:'sticky', top:90, alignSelf:'start', maxHeight:'calc(100vh - 110px)', overflow:'auto'}}>
         <div style={{background:'#fff', border:'2px solid #f0e8d8', borderRadius:18, padding:18}}>
           <div style={{display:'flex', alignItems:'center', gap:8, marginBottom:12}}>
             <div style={{fontSize:22}}>🔑</div>


### PR DESCRIPTION
## Summary

The article view's Read & Words tab uses a `1.6fr 1fr` grid: a long story body on the left, a short `<aside>` (Word Treasure glossary + optional "Why it matters") on the right. Without sticky, the right column scrolled away with the body, so by the time the user is mid-paragraph the keyword glossary they need to reference is off-screen.

Fix: add `position:'sticky', top:90, alignSelf:'start', maxHeight:'calc(100vh - 110px)', overflow:'auto'` to the aside (`website/article.jsx:561`). Mirrors the sticky pattern already used by the quiz tab's "Look back at the story" panel at `website/article.jsx:990`.

`alignSelf:'start'` is load-bearing — without it the grid item would stretch to row height and sticky would silently not stick.

## Test plan

- [ ] Open Vercel preview, visit any article (e.g. an article on https://kidsnews.21mins.com/)
- [ ] Scroll the page down on the default Read & Words tab
- [ ] Confirm Word Treasure / Why it matters panel stays visible at the top of the viewport while the story scrolls
- [ ] Expand a keyword card; confirm the aside scrolls internally if its content exceeds viewport height (no page-jump)

Closes #6

Bug-Record: `docs/bugs/2026-04-30-adjust-left-right-column-ratio.md`