### PR TITLE
fix(article): collapse Read & Words grid to single column on mobile

### DIFF
--- a/docs/bugs/2026-04-30-mobile-responsive-grid-collapse.md
+++ b/docs/bugs/2026-04-30-mobile-responsive-grid-collapse.md
@@ -1,0 +1,110 @@
+# 2026-04-30 — mobile-responsive-grid-collapse
+
+**Severity:** medium
+**Area:** website
+**Status:** fixed
+**Keywords:** article, layout, responsive, mobile, grid, matchmedia, useIsNarrow, read-and-words, story-page
+
+## Symptom
+
+User feedback (issue #6, feedback row 11, user level Tree, en, page
+URL `https://kidsnews.21mins.com/`) on 2026-04-30:
+
+> the story left side is too long comparing to right side. Maybe we
+> can use scroll or adjust the left right ratio to make it more
+> balance and easy to read.
+
+The reporting user was on mobile (iPhone Safari, ~375px viewport —
+visible from the admin's screenshot of the same view). On the
+article view's default Read & Words tab, the layout still rendered
+its desktop two-column grid on a phone, so the body got ~225px of
+horizontal space and the aside got ~140px. The body became a tall,
+skinny column of broken-up paragraphs while the aside stayed short
+— exactly the "left too long compared to right" imbalance.
+
+## Root cause
+
+`website/article.jsx:561` (post-fix line; was `:530` pre-fix) declared
+`gridTemplateColumns: '1.6fr 1fr'` with no media query and no
+responsive collapse. The codebase has zero existing matchMedia /
+@media / breakpoint usage anywhere — every grid is laid out with
+fixed `fr` ratios regardless of viewport. So on mobile, the desktop
+1.6fr/1fr ratio is preserved unchanged, which divides a 375px
+viewport into two cramped columns.
+
+The previous attempt (PR #8, reverted) added `position: sticky` to
+the right `<aside>`. That didn't address the cramped two-column
+problem at all — sticky just keeps the aside in view while you
+scroll, but the columns are still side-by-side and still cramped on
+a phone. Wrong axis of fix entirely.
+
+## Fix
+
+PR: opened against `main` from branch
+`fix/issue-6-mobile-responsive-grid`. Closes #6.
+
+- `website/article.jsx:9-27` — added `useIsNarrow(maxWidth)` hook.
+  Reads `window.matchMedia(...).matches` for initial state and
+  subscribes to `change` events for live updates (so the layout
+  reflows if the user rotates the device or resizes the browser).
+  Falls back to the deprecated `addListener` API for Safari < 14.
+  Returns false in non-browser environments so SSR / build-time
+  evaluation never crashes.
+- `website/article.jsx:559` — `ReadAndWordsTab` calls
+  `useIsNarrow(768)` and switches `gridTemplateColumns` between
+  `'1fr'` (single column, stacked) when narrow and `'1.6fr 1fr'`
+  (the original two-column layout) when wide. The 768px breakpoint
+  is the conventional tablet/mobile boundary; below it the body
+  card and the aside (Word Treasure + optional "Why it matters")
+  each get full viewport width and stack vertically.
+
+The change is scoped intentionally to `ReadAndWordsTab` only. Other
+tabs (`BackgroundTab`, `QuizTab`, `MyTakeTab`) and the search/home
+views also use rigid `fr` grids and likely have similar mobile
+cramping, but those are separate fixes — see Related.
+
+## Invariant
+
+`ReadAndWordsTab`'s grid MUST collapse to a single column on
+viewports ≤768px. Future edits to the grid-template at
+`article.jsx:561` MUST keep the `isNarrow ? '1fr' : ...'` ternary
+(or an equivalent media query) — replacing it with a fixed
+multi-column ratio re-introduces the cramped mobile layout that
+issue #6 reported.
+
+`useIsNarrow` MUST remain defined before any function that calls it
+in render (currently only `ReadAndWordsTab`). It is a normal hook
+and must not be called conditionally.
+
+## Pinning test
+
+MANUAL (30s click-through):
+1. Open any article in a browser at desktop width — the Read &
+   Words tab should still render two columns (story on left, Word
+   Treasure on right) at the existing 1.6fr/1fr ratio.
+2. Resize the browser narrower than 768px (or open Chrome DevTools
+   device-toolbar at iPhone 12, 390x844). The two columns must
+   reflow into a single stacked column: story body full-width on
+   top, Word Treasure (and "Why it matters" if present) full-width
+   below.
+3. Resize back wider than 768px without reloading — the layout
+   must reflow back to two columns. (This proves the matchMedia
+   `change` listener is wired up; if it stays single-column even
+   at desktop width after a resize, the listener regressed.)
+
+## Related
+
+- PR #8 (reverted on 2026-04-30) — the previous, wrong-angle attempt
+  at this issue. Added `position: sticky` to the aside; the admin
+  rolled it back. Don't revisit that approach without first stacking
+  on mobile.
+- `website/article.jsx:840`, `:1008`, `:1262` (approximate; was
+  `:820 / :988 / :1242` pre-fix, lines shift with the new hook block)
+  — `BackgroundTab`, `QuizTab`, `MyTakeTab` use the same fixed-fr
+  grid pattern and likely cramp on mobile in the same way. Out of
+  scope for this PR; can reuse `useIsNarrow` when each is fixed.
+- `website/home.jsx`, `website/parent.jsx` — also have rigid grids
+  with no responsive collapse.
+- `~/myprojects/lessons/universal-patterns.md` — the
+  "responsive-collapse-on-mobile" pattern would belong here once a
+  second project hits the same trap.

--- a/docs/bugs/INDEX.md
+++ b/docs/bugs/INDEX.md
@@ -16,6 +16,7 @@ you must not break.
 
 | Date | Sev | Area | Record | Symptom | Keywords |
 |---|---|---|---|---|---|
+| 2026-04-30 | medium | website | [mobile-responsive-grid-collapse](2026-04-30-mobile-responsive-grid-collapse.md) | Article Read & Words tab kept its 1.6fr/1fr grid on phones, cramping body+aside; first attempt (sticky aside, PR #8) was reverted — fix collapses to single column below 768px | article, layout, responsive, mobile, grid, matchmedia, useIsNarrow, read-and-words |
 | 2026-04-30 | medium | infra | [supabase-edge-fn-html-blocked](2026-04-30-supabase-edge-fn-html-blocked.md) | Supabase Edge Functions silently override Content-Type to text/plain + add sandbox CSP, breaking HTML rendering in browsers | supabase, edge-function, content-type, csp, sandbox, html |
 | 2026-04-29 | medium | infra | [autofix-token-starvation](2026-04-29-autofix-token-starvation.md) | Autofix daemon's back-to-back claude -p calls starved the user's IDE of API quota for ~2 min | claude, headless, daemon, rate-limit, concurrency, autofix |
 | 2026-04-29 | high | website | [search-click-wrong-article](2026-04-29-search-click-wrong-article.md) | Clicking a search hit always opened today's first article instead of the searched one | search, archive, ARTICLES.find, listing-overwrite, synthetic-merge |

--- a/website/article.jsx
+++ b/website/article.jsx
@@ -1,6 +1,31 @@
 // Article detail page — News Oh,Ye!
 const { useState: useStateA, useMemo: useMemoA, useEffect: useEffectA, useRef: useRefA } = React;
 
+// Reactive viewport-narrow detector. Returns true while the viewport
+// is at or below `maxWidth` px so a layout can collapse a multi-column
+// grid into a single column on phones. The codebase has no other
+// matchMedia callers — keep this hook here scoped to article.jsx
+// rather than a shared helper until a second caller appears.
+function useIsNarrow(maxWidth) {
+  const query = `(max-width: ${maxWidth}px)`;
+  const [narrow, setNarrow] = useStateA(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return false;
+    return window.matchMedia(query).matches;
+  });
+  useEffectA(() => {
+    if (typeof window === 'undefined' || !window.matchMedia) return;
+    const mql = window.matchMedia(query);
+    const handler = (e) => setNarrow(e.matches);
+    if (mql.addEventListener) {
+      mql.addEventListener('change', handler);
+      return () => mql.removeEventListener('change', handler);
+    }
+    mql.addListener(handler);
+    return () => mql.removeListener(handler);
+  }, [query]);
+  return narrow;
+}
+
 // Format an ISO-8601 timestamp as "Apr 24, 2026". Returns "" on bad input
 // so callers can safely conditionally render.
 function formatDate(iso) {
@@ -526,8 +551,14 @@ function pdfUrlForArticle(article) {
 function ReadAndWordsTab({ article, paragraphs, expanded, setExpanded, onFinish }) {
   const catColor = getCatColor(article.category);
   const [gameOpen, setGameOpen] = useStateA(false);
+  // Below ~768px a 1.6fr/1fr grid forces the body to ~225px and the
+  // aside to ~140px on a typical phone — both columns become cramped
+  // and the user reports the body looks "too long" relative to the
+  // short aside. Stack into a single column on narrow viewports so
+  // the body uses full width and the aside flows below at full width.
+  const isNarrow = useIsNarrow(768);
   return (
-    <div style={{display:'grid', gridTemplateColumns:'1.6fr 1fr', gap:24}}>
+    <div style={{display:'grid', gridTemplateColumns: isNarrow ? '1fr' : '1.6fr 1fr', gap:24}}>
       <div style={{background:'#fff', borderRadius:22, padding:'30px 34px', border:'2px solid #f0e8d8'}}>
         <div style={{display:'flex', alignItems:'center', gap:10, marginBottom:18, paddingBottom:14, borderBottom:'2px dashed #f0e8d8'}}>
           <div style={{fontSize:26}}>📖</div>


### PR DESCRIPTION
## Summary

Issue #6 reports the article view's Read & Words tab feels visually
unbalanced — "left side too long compared to right side". The
reporter is on iPhone Safari (~375px viewport).

`website/article.jsx:530` (pre-fix) declared
`gridTemplateColumns: '1.6fr 1fr'` with no media query and no
responsive collapse. On a 375px phone that gives the story body
~225px and the aside ~140px — both columns become cramped and the
tall body next to a short aside is the imbalance the user described.

The previous attempt (PR #8, reverted) added `position: sticky` to
the right `<aside>`. That doesn't help at mobile widths — sticky
keeps a column in view while you scroll, but the columns are still
side-by-side and still cramped on a phone. Wrong axis of fix.

This PR takes a different angle:

- **`website/article.jsx:9-27`** — adds a small `useIsNarrow(maxWidth)`
  hook. Reads `window.matchMedia` for initial state and subscribes
  to `change` events so the layout reflows on rotate/resize. Falls
  back to the deprecated `addListener` API for Safari < 14. The
  codebase had zero existing matchMedia / @media usage so this is
  net-new helper, scoped to `article.jsx` until a second caller
  appears.
- **`website/article.jsx:559-561`** — `ReadAndWordsTab` calls
  `useIsNarrow(768)` and switches `gridTemplateColumns` between
  `'1fr'` (single stacked column) when narrow and `'1.6fr 1fr'`
  (the original two-column layout) when wide. 768px is the
  conventional tablet/mobile breakpoint.

Scoped to `ReadAndWordsTab` only. Other tabs (Background / Quiz /
MyTake) and the home/parent views also use rigid `fr` grids and
likely have similar mobile cramping — out of scope here, called
out in the bug record's Related section.

## Test plan

- [ ] Open Vercel preview on a desktop browser at the article view's
      default Read & Words tab — should still render two columns
      (story left, Word Treasure right) at the existing 1.6fr/1fr
      ratio.
- [ ] Resize the browser narrower than 768px (or use Chrome DevTools
      device toolbar at iPhone 12, 390x844). The two columns must
      reflow into a single stacked column: body full-width on top,
      Word Treasure (and "Why it matters" if present) full-width
      below.
- [ ] Resize back wider than 768px without reloading — layout must
      reflow back to two columns. Proves the matchMedia `change`
      listener is wired up.
- [ ] On mobile, scrolling through the body should feel uncramped
      (full viewport width, normal paragraph length). The keyword
      glossary appears below, not crammed into a 140px sliver.

Closes #6
Bug-Record: docs/bugs/2026-04-30-mobile-responsive-grid-collapse.md