### PR TITLE
feat(pipeline): support html_list + sitemap feed_kinds

### DIFF
--- a/docs/HANDOVER-from-sourcefinder-html_list.md
+++ b/docs/HANDOVER-from-sourcefinder-html_list.md
@@ -1,0 +1,236 @@
+# Handover from sourcefinder → news-v2: support `html_list` feed kind
+
+**From:** `~/myprojects/sourcefinder` (mining-only project)
+**To:**   `~/myprojects/news-v2` (production pipeline that fetches & serves)
+**Date:** 2026-05-03
+**Driver:** sourcefinder is about to promote 4 sources, **3 of which are
+`html_list` not RSS**. news-v2's current daily pipeline only knows RSS —
+these will fail at fetch time if promoted as-is.
+
+## TL;DR
+
+1. Add `feed_kind` + `feed_config` columns to `redesign_source_configs`.
+2. Port `sourcefinder/scraper.py` into news-v2 (or copy it inline).
+3. At the daily pipeline's RSS-fetch step, dispatch by `feed_kind`.
+4. **Do NOT modify `pipeline/cleaner.py`** — it stays as-is. Body
+   extraction is already feed-kind-agnostic (it operates on whatever
+   HTML is fetched).
+
+## Why this is needed (context)
+
+`sourcefinder` mines candidate publishers via 3 feed shapes:
+
+- `rss` — XML RSS/Atom feed (the historical case news-v2 already handles)
+- `sitemap` — `sitemap.xml` (sitemapindex → sub-sitemap → urlset)
+- `html_list` — HTML listing page where article links are extracted via a
+  CSS selector
+
+Round-1 + round-2 brainstorms surfaced ~40% non-RSS sources. The 4 sources
+ready to promote on 2026-05-03:
+
+| id | name | feed_kind | URL |
+|---|---|---|---|
+| 15 | Smithsonian Smart News | `rss` | https://www.smithsonianmag.com/rss/smart-news/ |
+| 24 | DOGOnews | `html_list` | https://www.dogonews.com/ |
+| 25 | Live Science | `rss` | https://www.livescience.com/feeds/all |
+| 35 | NG Kids — Space | `html_list` | https://kids.nationalgeographic.com/space/ |
+
+Only #15 and #25 work in the current pipeline. #24 and #35 need this work.
+
+Going forward sourcefinder will keep promoting more `html_list` sources —
+some of the strongest candidates are explicitly built for kids and don't
+publish RSS (NG Kids family, kid-magazine sites, etc.).
+
+## What changes
+
+### 1. Schema — add 2 columns to `redesign_source_configs`
+
+```sql
+ALTER TABLE redesign_source_configs
+    ADD COLUMN feed_kind TEXT NOT NULL DEFAULT 'rss';
+
+ALTER TABLE redesign_source_configs
+    ADD COLUMN feed_config TEXT;  -- JSON; nullable for feed_kind='rss'
+```
+
+Existing rows default to `feed_kind='rss'` — backward-compatible.
+
+The `redesign_source_candidates` table can stay as-is (passive; sourcefinder
+uses local SQLite for in-flight candidates).
+
+### 2. Code — port the scraper module
+
+The canonical implementation lives at `~/myprojects/sourcefinder/sourcefinder/scraper.py`.
+It's ~250 lines, pure-Python (urllib + bs4 + xml.etree). Recommended:
+**copy it into news-v2 as `pipeline/scraper.py`** — duplicate code beats
+cross-repo Python imports.
+
+Key entry point:
+
+```python
+from pipeline.scraper import discover_article_urls
+
+# `source` is a dict-like row from redesign_source_configs with at minimum:
+#   rss_url, feed_kind, feed_config (JSON string or None)
+items = discover_article_urls(source, top_n=5)
+# Returns: [{"url": str, "title": str, "description": str, ...}, ...]
+```
+
+Behavior by `feed_kind`:
+
+```
+feed_kind='rss'        — uses rss_url as RSS/Atom feed URL
+feed_kind='sitemap'    — uses rss_url as sitemap.xml URL
+                         feed_config: {"subsitemap_filter": "...",
+                                       "url_filter": "...",
+                                       "max_items": 200}
+feed_kind='html_list'  — uses rss_url as HTML listing page URL
+                         feed_config: {"article_selector": "css selector",
+                                       "exclude_pattern": "regex",
+                                       "title_selector": "css selector"}
+```
+
+The scraper has built-in retry policy (3 UAs cycled, ~60s budget) for
+publisher anti-bot resilience. Keep that — it's already saved us on Live
+Science (transient WAF block).
+
+### 3. Daily pipeline integration
+
+Wherever news-v2's daily pipeline currently does:
+
+```python
+# Conceptual current path
+for source in active_sources:
+    items = fetch_rss(source.rss_url)        # ← only handles RSS
+    for item in items[:N]:
+        article_html = fetch(item.link)
+        body = extract_article_from_html(item.link, article_html)  # cleaner.py
+        ...
+```
+
+Change to:
+
+```python
+from pipeline.scraper import discover_article_urls
+
+for source in active_sources:
+    items = discover_article_urls(source, top_n=N)  # ← all 3 feed_kinds
+    for item in items[:N]:
+        article_html = fetch(item["url"])
+        body = extract_article_from_html(item["url"], article_html)  # unchanged
+        ...
+```
+
+`extract_article_from_html` (the production cleaner) is **untouched**. It
+already operates on any HTML regardless of how the URL was discovered.
+
+### 4. Reddit-specific outbound link follow
+
+If news-v2 ever ingests Reddit RSS feeds (sourcefinder rejected them all but
+some may still be in `redesign_source_configs` from earlier), the
+description's `[link]` anchor needs to be followed before passing to the
+cleaner. See `bin/daily_verify.py:extract_outbound_from_reddit_desc` in
+sourcefinder for the helper. Optional — only relevant if you keep any
+`reddit.com` sources active.
+
+## Test cases (validate before promote)
+
+After the migration + code change, validate with these 3 `html_list`
+candidates that sourcefinder is about to promote. They should fetch
+articles + extract bodies cleanly via the existing `extract_article_from_html`:
+
+```sql
+INSERT INTO redesign_source_configs
+    (category, name, rss_url, feed_kind, feed_config, state)
+VALUES
+    ('Fun', 'DOGOnews',
+     'https://www.dogonews.com/',
+     'html_list',
+     '{"article_selector": "article a[href*=\"/2026\"], article a[href*=\"/2025\"]", "exclude_pattern": "#comment"}',
+     'live'),
+
+    ('Fun', 'NG Kids — Space',
+     'https://kids.nationalgeographic.com/space/',
+     'html_list',
+     '{"article_selector": "a[href*=\"/space/\"][href*=\"/article/\"]"}',
+     'live'),
+
+    ('Fun', 'NG Kids — Geography',
+     'https://kids.nationalgeographic.com/geography/',
+     'html_list',
+     '{"article_selector": "a[href*=\"/geography/\"]", "exclude_pattern": "/games/|/videos/"}',
+     'live');
+```
+
+Expected behavior at next pipeline run:
+
+- DOGOnews: 3 articles, ~334 wc avg, all with og:image
+- NG Kids — Space: 3 articles, ~247 wc avg, all with og:image (some shorter)
+- NG Kids — Geography: 3 articles, ~682 wc avg, all with og:image
+
+If any source returns 0 articles → the selector needs adjustment OR the
+site changed. Sourcefinder's daily verify catches this and notifies.
+
+## Image fallback (optional but recommended)
+
+If `extract_article_from_html` returns `og_image=None`, news-v2 may want to
+fall back to a body `<img>` tag — same logic sourcefinder uses for NASA
+APOD-style pages. Reference implementation:
+`~/myprojects/sourcefinder/bin/daily_verify.py::_fallback_body_image`.
+
+About 30 lines, optional. Without it, sources whose pages don't have
+`<meta og:image>` will surface without hero images in news-v2 output.
+
+## What sourcefinder commits to do once news-v2 is ready
+
+`bin/promote.py` in sourcefinder currently strips `feed_kind` and
+`feed_config` before INSERT (left over from before this work). Once
+news-v2 supports the new columns, ping sourcefinder and we update
+`bin/promote.py:to_remote_payload()` to pass them through.
+
+Until then: only RSS sources are promotable to production. Sourcefinder
+will hold `html_list` candidates in `state='good'` (ready, but waiting
+on news-v2).
+
+## Coordination protocol
+
+1. news-v2 maintainer applies migration + code change
+2. news-v2 maintainer runs the 3 test INSERTs above on a staging branch
+3. Verify next pipeline run picks up all 3 `html_list` sources successfully
+4. Merge to production
+5. Ping sourcefinder; we update `bin/promote.py` to send `feed_kind` +
+   `feed_config` going forward
+6. From that point on, sourcefinder can promote `html_list` sources directly
+   via `python -m bin.promote --id N`
+
+## Reference: full scraper.py contents
+
+For convenience (since cross-repo imports are fragile), the canonical
+scraper module is at:
+
+  `/Users/jiong/myprojects/sourcefinder/sourcefinder/scraper.py`
+
+~250 lines, dependencies: `bs4`, `lxml`, stdlib. Already in news-v2's
+requirements (used by cleaner.py). Just copy the file.
+
+If you'd rather not duplicate, you can `pip install -e
+~/myprojects/sourcefinder` and import — but that creates a runtime
+dependency that's annoying to track. **Recommend copy.**
+
+## Out of scope
+
+- **No changes to cleaner.py** — body extraction logic stays canonical.
+- **No changes to image scoring or kid-safety logic** — that's all in
+  sourcefinder, doesn't affect production.
+- **No changes to news-v2's read path** — the daily pipeline change is
+  isolated to the fetch/discover step.
+
+## Questions / blockers
+
+If anything's unclear about the scraper behavior or the schema migration,
+the sourcefinder repo has empirical results from running this in
+production for 3+ days against ~50 candidate sources — see
+`~/myprojects/sourcefinder/docs/scheduled-tasks-howto.md` (the
+context-exhaustion section especially) and
+`~/myprojects/sourcefinder/out/daily-verify-2026-05-*.json` for real
+sample data showing what each `feed_kind` produces.

--- a/pipeline/db_config.py
+++ b/pipeline/db_config.py
@@ -95,6 +95,8 @@ def _row_to_source(row: dict) -> NewsSource:
         enabled=bool(row.get("enabled") if row.get("enabled") is not None else True),
         is_backup=bool(row.get("is_backup") or False),
         notes=row.get("notes") or "",
+        feed_kind=row.get("feed_kind") or "rss",
+        feed_config=row.get("feed_config"),
     )
 
 

--- a/pipeline/news_rss_core.py
+++ b/pipeline/news_rss_core.py
@@ -254,6 +254,41 @@ def fetch_rss_entries(url: str, max_entries: int = MAX_RSS_DEFAULT,
     return out
 
 
+def fetch_source_entries(source, max_entries: int = MAX_RSS_DEFAULT,
+                         max_age_days: float = MAX_RSS_AGE_DAYS_DEFAULT) -> list[dict]:
+    """Discover recent article entries from a source, dispatching by
+    `source.feed_kind`. Returns the same dict shape as fetch_rss_entries
+    (`title`, `link`, `published`, `summary`) so downstream code is
+    feed-kind-blind.
+
+    - rss        → delegates to fetch_rss_entries (5-day freshness applied).
+    - sitemap    → uses scraper._from_sitemap; lastmod (if present) maps to
+                   `published`. No freshness filter (sitemaps are usually
+                   already date-ordered).
+    - html_list  → uses scraper._from_html_list. Listing pages don't carry
+                   per-item dates, so freshness relies on the page's own
+                   recency (publishers put recent articles at the top).
+    """
+    kind = (getattr(source, "feed_kind", None) or "rss").lower()
+    if kind == "rss":
+        return fetch_rss_entries(source.rss_url, max_entries, max_age_days)
+
+    from .scraper import discover_article_urls
+    items = discover_article_urls({
+        "rss_url": source.rss_url,
+        "feed_kind": kind,
+        "feed_config": source.feed_config,
+    }, top_n=max_entries)
+    log.info("%s discovery [%s]: %d items",
+             kind, source.rss_url[:80], len(items))
+    return [{
+        "title":     i.get("title") or "",
+        "link":      i["url"],
+        "published": i.get("lastmod") or "",
+        "summary":   i.get("description") or "",
+    } for i in items]
+
+
 def fetch_html(url: str) -> str | None:
     try:
         r = requests.get(url, timeout=HTML_FETCH_TIMEOUT, headers=HTML_FETCH_HEADERS,
@@ -1624,9 +1659,10 @@ def run_source_phase_a(source, html_tag_stripper=None) -> dict | None:
     from .cleaner import extract_article_from_html
     import re as _re
 
-    log.info("[%s] Phase A: flow=%s", source.name, source.flow)
-    rss_entries = fetch_rss_entries(source.rss_url, max_entries=25)
-    log.info("[%s]  RSS entries: %d", source.name, len(rss_entries))
+    log.info("[%s] Phase A: flow=%s feed_kind=%s",
+             source.name, source.flow, getattr(source, "feed_kind", "rss"))
+    rss_entries = fetch_source_entries(source, max_entries=25)
+    log.info("[%s]  entries: %d", source.name, len(rss_entries))
 
     if source.flow == "full":
         processed = [process_entry(e, min_words=source.min_body_words) for e in rss_entries]

--- a/pipeline/news_sources.py
+++ b/pipeline/news_sources.py
@@ -21,6 +21,8 @@ class NewsSource:
     enabled: bool
     is_backup: bool
     notes: str = ""
+    feed_kind: str = "rss"          # rss | sitemap | html_list
+    feed_config: str | None = None  # JSON; None for feed_kind='rss'
 
     @property
     def is_light(self) -> bool:

--- a/pipeline/scraper.py
+++ b/pipeline/scraper.py
@@ -1,0 +1,297 @@
+"""Article URL discovery for sources of various shapes.
+
+Three feed kinds are supported. All three return a uniform
+list[dict] of `{url, title, description}` so downstream code (the
+verifier, daily_verify) doesn't care which shape the source has.
+
+  feed_kind='rss'        — XML RSS/Atom feed at rss_url.
+                           No feed_config needed.
+  feed_kind='sitemap'    — sitemap.xml at rss_url. feed_config:
+                             { "subsitemap_filter": "posts-post",  # which sub-sitemap to follow if
+                                                                   #   the root is a sitemapindex
+                                                                   #   (default: pick first)
+                               "url_filter": "/articles/",         # regex; only keep urlset URLs matching
+                                                                   #   (default: keep all)
+                               "max_items": 50,                    # how many sitemap entries to consider
+                             }
+  feed_kind='html_list'  — HTML listing page at rss_url. feed_config:
+                             { "article_selector": "article h2 a",  # CSS selector for <a> elements
+                               "title_selector":   "h2",            # optional: extract title from
+                                                                    #   the matched element
+                               "exclude_pattern":  "/category/|/tag/",
+                             }
+
+Constraint (per project rule): scraping uses Python libs only — NO LLM.
+
+Public entry point:
+
+    discover_article_urls(source: dict, top_n: int = 5) -> list[dict]
+        # source is a row from candidates table (dict-like).
+        # Returns up to top_n items, newest-first when known.
+"""
+from __future__ import annotations
+
+import json
+import re
+import xml.etree.ElementTree as ET
+from typing import Any
+from urllib.error import HTTPError, URLError
+from urllib.parse import urljoin, urlparse
+from urllib.request import Request, urlopen
+
+from bs4 import BeautifulSoup
+
+UA_DEFAULT = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) "
+    "AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0.0.0 Safari/537.36"
+)
+UA_GOOGLEBOT = "Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)"
+UA_FIREFOX = (
+    "Mozilla/5.0 (Macintosh; Intel Mac OS X 10.15; rv:124.0) Gecko/20100101 Firefox/124.0"
+)
+UA = UA_DEFAULT  # back-compat
+TIMEOUT = 20
+ATOM_NS = "{http://www.w3.org/2005/Atom}"
+SITEMAP_NS = "{http://www.sitemaps.org/schemas/sitemap/0.9}"
+
+# Per project rule: if a fetch can't succeed within ~60s after trying 2-3
+# common workarounds (UA cycling + retry on transient errors), give up.
+TOTAL_BUDGET_SEC = 60
+
+
+def _fetch_once(url: str, ua: str, timeout: int) -> tuple[str, str, str]:
+    req = Request(url, headers={
+        "User-Agent": ua,
+        "Accept": (
+            "text/html,application/xhtml+xml,application/rss+xml,"
+            "application/atom+xml,application/xml,*/*;q=0.8"
+        ),
+        "Accept-Language": "en-US,en;q=0.9",
+    })
+    with urlopen(req, timeout=timeout) as r:
+        body = r.read()
+        for enc in ("utf-8", "latin-1"):
+            try:
+                return body.decode(enc), r.headers.get("Content-Type", ""), r.url
+            except UnicodeDecodeError:
+                continue
+        return body.decode("utf-8", errors="replace"), r.headers.get("Content-Type", ""), r.url
+
+
+def _fetch(url: str, timeout: int = TIMEOUT) -> tuple[str, str, str]:
+    """Fetch URL with retry policy: try default UA, then Googlebot, then Firefox.
+
+    Total budget ~60s. Retries cover 403 (WAF rate-limit), timeouts, and
+    transient connection errors. Persistent 404 (real bad URL) does NOT retry.
+    """
+    import time
+    deadline = time.time() + TOTAL_BUDGET_SEC
+    last_err: Exception | None = None
+    for attempt, ua in enumerate([UA_DEFAULT, UA_GOOGLEBOT, UA_FIREFOX], 1):
+        if time.time() >= deadline:
+            break
+        try:
+            return _fetch_once(url, ua, min(timeout, max(2, int(deadline - time.time()))))
+        except HTTPError as e:
+            last_err = e
+            if e.code in (404, 410, 451):
+                # Real "not there" — UA won't help.
+                raise
+            # 403 / 429 / 5xx — back off briefly then try next UA
+            time.sleep(min(3, max(1, deadline - time.time() - 1)))
+        except (URLError, TimeoutError, OSError) as e:
+            last_err = e
+            time.sleep(min(2, max(1, deadline - time.time() - 1)))
+    if last_err:
+        raise last_err
+    raise RuntimeError("fetch budget exhausted with no specific error")
+
+
+# ── RSS / Atom ──────────────────────────────────────────────────────
+
+def _from_rss(rss_url: str, top_n: int) -> list[dict]:
+    text, _, _ = _fetch(rss_url)
+    text = text.lstrip("﻿")
+    items: list[dict] = []
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as e:
+        raise RuntimeError(f"RSS parse error: {e}") from None
+
+    # RSS 2.0 <item>
+    for it in root.iter("item"):
+        l = it.find("link"); t = it.find("title"); d = it.find("description")
+        link = (l.text or "").strip() if l is not None and l.text else ""
+        title = (t.text or "").strip() if t is not None and t.text else ""
+        desc = (d.text or "").strip() if d is not None and d.text else ""
+        if link:
+            items.append({"url": link, "title": title, "description": desc})
+
+    # Atom <entry>
+    if not items:
+        for entry in root.iter(f"{ATOM_NS}entry"):
+            link = ""
+            for le in entry.findall(f"{ATOM_NS}link"):
+                if (le.get("rel") or "alternate") == "alternate" and le.get("href"):
+                    link = le.get("href").strip(); break
+            if not link:
+                le = entry.find(f"{ATOM_NS}link")
+                if le is not None and le.get("href"):
+                    link = le.get("href").strip()
+            t = entry.find(f"{ATOM_NS}title")
+            title = (t.text or "").strip() if t is not None and t.text else ""
+            desc = ""
+            for tag in (f"{ATOM_NS}summary", f"{ATOM_NS}content"):
+                el = entry.find(tag)
+                if el is not None and el.text:
+                    desc = el.text.strip(); break
+            if link:
+                items.append({"url": link, "title": title, "description": desc})
+
+    return items[:top_n]
+
+
+# ── sitemap.xml ─────────────────────────────────────────────────────
+
+def _from_sitemap(
+    sitemap_url: str,
+    url_filter: str | None,
+    subsitemap_filter: str | None,
+    max_items: int,
+    top_n: int,
+) -> list[dict]:
+    text, _, _ = _fetch(sitemap_url)
+    text = text.lstrip("﻿")
+    try:
+        root = ET.fromstring(text)
+    except ET.ParseError as e:
+        raise RuntimeError(f"sitemap parse error: {e}") from None
+
+    # If this is a sitemapindex, follow ONE sub-sitemap (chosen by subsitemap_filter,
+    # else the first). Inside that sub-sitemap we still apply url_filter at the
+    # urlset level — these two filters are separate concerns and were tangled
+    # together in the previous version.
+    if root.tag == f"{SITEMAP_NS}sitemapindex":
+        sub = [el for el in root.findall(f"{SITEMAP_NS}sitemap/{SITEMAP_NS}loc") if el.text]
+        urls = [el.text.strip() for el in sub]
+        chosen = None
+        if subsitemap_filter:
+            for u in urls:
+                if subsitemap_filter in u:
+                    chosen = u; break
+        if not chosen and urls:
+            chosen = urls[0]
+        if chosen:
+            return _from_sitemap(chosen, url_filter, subsitemap_filter, max_items, top_n)
+        raise RuntimeError("sitemapindex with no usable sub-sitemap")
+
+    # urlset — apply url_filter (if any) only here.
+    items: list[dict] = []
+    pat = re.compile(url_filter) if url_filter else None
+    for url_el in root.iter(f"{SITEMAP_NS}url"):
+        loc_el = url_el.find(f"{SITEMAP_NS}loc")
+        last_el = url_el.find(f"{SITEMAP_NS}lastmod")
+        if loc_el is None or not loc_el.text:
+            continue
+        u = loc_el.text.strip()
+        if pat and not pat.search(u):
+            continue
+        items.append({
+            "url": u,
+            "title": "",  # sitemaps don't carry titles
+            "description": "",
+            "lastmod": last_el.text.strip() if last_el is not None and last_el.text else "",
+        })
+        if len(items) >= max_items:
+            break
+
+    # newest-first if lastmod present (most sites populate it)
+    items.sort(key=lambda x: x.get("lastmod") or "", reverse=True)
+    return items[:top_n]
+
+
+# ── HTML listing page ──────────────────────────────────────────────
+
+def _from_html_list(
+    list_url: str,
+    article_selector: str,
+    title_selector: str | None,
+    exclude_pattern: str | None,
+    top_n: int,
+) -> list[dict]:
+    text, _, final_url = _fetch(list_url)
+    soup = BeautifulSoup(text, "lxml")
+
+    excl = re.compile(exclude_pattern) if exclude_pattern else None
+    seen: set[str] = set()
+    items: list[dict] = []
+
+    for el in soup.select(article_selector):
+        # If selector targets <a>, that's the link element; otherwise, find <a> inside.
+        anchor = el if el.name == "a" else el.find("a")
+        if not anchor or not anchor.get("href"):
+            continue
+
+        url = urljoin(final_url, anchor["href"].strip())
+        if url in seen:
+            continue
+        if excl and excl.search(url):
+            continue
+        # filter out fragments and same-page anchors
+        if url.startswith("javascript:") or "#" == urlparse(url).fragment[:1]:
+            continue
+        # only keep same-host links by default (publisher-internal articles)
+        if urlparse(url).netloc and urlparse(url).netloc != urlparse(final_url).netloc:
+            continue
+
+        # Title extraction
+        title = ""
+        if title_selector:
+            t_el = el.select_one(title_selector) or anchor
+            title = t_el.get_text(" ", strip=True)
+        else:
+            title = anchor.get_text(" ", strip=True) or anchor.get("title", "")
+        title = re.sub(r"\s+", " ", title).strip()[:200]
+
+        seen.add(url)
+        items.append({"url": url, "title": title, "description": ""})
+        if len(items) >= top_n * 3:  # collect extra in case some are duplicates / filtered later
+            break
+
+    return items[:top_n]
+
+
+# ── Public entry point ─────────────────────────────────────────────
+
+def discover_article_urls(source: dict, top_n: int = 5) -> list[dict]:
+    """Dispatch to the right shape implementation based on source['feed_kind']."""
+    kind = (source.get("feed_kind") or "rss").lower()
+    cfg_raw = source.get("feed_config") or "{}"
+    cfg: dict[str, Any] = json.loads(cfg_raw) if isinstance(cfg_raw, str) else cfg_raw
+    primary_url = source.get("rss_url")
+
+    if kind == "rss":
+        return _from_rss(primary_url, top_n)
+
+    if kind == "sitemap":
+        return _from_sitemap(
+            primary_url,
+            cfg.get("url_filter"),
+            cfg.get("subsitemap_filter"),
+            cfg.get("max_items", 200),
+            top_n,
+        )
+
+    if kind == "html_list":
+        return _from_html_list(
+            primary_url,
+            cfg["article_selector"],
+            cfg.get("title_selector"),
+            cfg.get("exclude_pattern"),
+            top_n,
+        )
+
+    raise ValueError(f"unknown feed_kind: {kind!r}")
+
+
+__all__ = ["discover_article_urls"]

--- a/pipeline/test_scraper_html_list.py
+++ b/pipeline/test_scraper_html_list.py
@@ -1,0 +1,128 @@
+"""Offline smoke test for pipeline.scraper html_list path + the
+fetch_source_entries dispatcher.
+
+Run: python -m pipeline.test_scraper_html_list
+
+No network — all fetches are monkey-patched. Asserts that:
+  1. _from_html_list parses an inline DOGOnews-shaped listing page
+     correctly (article URLs extracted, junk filtered).
+  2. fetch_source_entries dispatches to the right backend by feed_kind
+     and returns the unified {title, link, published, summary} shape.
+"""
+from __future__ import annotations
+
+import json
+import sys
+from unittest.mock import patch
+
+from . import scraper
+from .news_rss_core import fetch_source_entries
+from .news_sources import NewsSource
+
+# A fixture mimicking a kid-news listing page. Two real article anchors,
+# one bad anchor (different host), one excluded by exclude_pattern, and
+# duplicate of the first.
+LIST_PAGE_HTML = """
+<html><body>
+  <article>
+    <a href="/2026/5/3/giraffes-can-hum">Scientists discover giraffes can hum</a>
+  </article>
+  <article>
+    <a href="/2026/5/2/space-elevator">Could a space elevator work?</a>
+  </article>
+  <article>
+    <a href="/games/some-game">Play this game</a>  <!-- excluded -->
+  </article>
+  <a href="https://other-site.com/external">External link</a>  <!-- different host -->
+  <article>
+    <a href="/2026/5/3/giraffes-can-hum">Same as #1</a>  <!-- duplicate -->
+  </article>
+</body></html>
+"""
+
+
+def fake_fetch(url, timeout=20):
+    return LIST_PAGE_HTML, "text/html", url
+
+
+def test_html_list_extraction() -> None:
+    src = {
+        "rss_url": "https://www.dogonews.com/",
+        "feed_kind": "html_list",
+        "feed_config": json.dumps({
+            "article_selector": "article a",
+            "exclude_pattern": "/games/",
+        }),
+    }
+    with patch.object(scraper, "_fetch", side_effect=fake_fetch):
+        items = scraper.discover_article_urls(src, top_n=5)
+
+    assert len(items) == 2, f"expected 2 unique articles, got {len(items)}: {items}"
+    urls = [i["url"] for i in items]
+    assert urls[0] == "https://www.dogonews.com/2026/5/3/giraffes-can-hum"
+    assert urls[1] == "https://www.dogonews.com/2026/5/2/space-elevator"
+    assert all("title" in i and "url" in i for i in items)
+    assert all(not i["url"].startswith("https://other-site.com") for i in items)
+    assert all("/games/" not in i["url"] for i in items)
+    print("PASS: _from_html_list extracted 2 unique same-host article URLs, junk filtered")
+
+
+def test_dispatcher_html_list() -> None:
+    """fetch_source_entries(NewsSource(feed_kind=html_list)) returns
+    the unified {title, link, published, summary} shape."""
+    src = NewsSource(
+        id=999, name="DOGOnews-test",
+        rss_url="https://www.dogonews.com/",
+        flow="full", max_to_vet=5, min_body_words=200,
+        priority=99, enabled=True, is_backup=False,
+        feed_kind="html_list",
+        feed_config=json.dumps({
+            "article_selector": "article a",
+            "exclude_pattern": "/games/",
+        }),
+    )
+    with patch.object(scraper, "_fetch", side_effect=fake_fetch):
+        entries = fetch_source_entries(src, max_entries=5)
+
+    assert len(entries) == 2, f"expected 2 entries, got {len(entries)}"
+    e0 = entries[0]
+    assert set(e0.keys()) == {"title", "link", "published", "summary"}, \
+        f"shape mismatch: {e0.keys()}"
+    assert e0["link"] == "https://www.dogonews.com/2026/5/3/giraffes-can-hum"
+    assert e0["title"] == "Scientists discover giraffes can hum"
+    print("PASS: fetch_source_entries returned 2 shape-compatible dicts for html_list")
+
+
+def test_dispatcher_rss_unchanged() -> None:
+    """fetch_source_entries with feed_kind='rss' (default) delegates to
+    fetch_rss_entries — the existing path is untouched."""
+    src = NewsSource(
+        id=1, name="rss-test",
+        rss_url="https://example.com/feed.xml",
+        flow="full", max_to_vet=5, min_body_words=200,
+        priority=99, enabled=True, is_backup=False,
+        # feed_kind defaults to "rss"
+    )
+    sentinel = [{"title": "x", "link": "https://x", "published": "", "summary": ""}]
+    with patch("pipeline.news_rss_core.fetch_rss_entries", return_value=sentinel) as m:
+        entries = fetch_source_entries(src, max_entries=5)
+
+    m.assert_called_once_with("https://example.com/feed.xml", 5, 5.0)
+    assert entries is sentinel
+    print("PASS: feed_kind='rss' (default) delegates to fetch_rss_entries unchanged")
+
+
+def main() -> int:
+    try:
+        test_html_list_extraction()
+        test_dispatcher_html_list()
+        test_dispatcher_rss_unchanged()
+    except AssertionError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        return 1
+    print("\nAll 3 tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline/verify_source.py
+++ b/pipeline/verify_source.py
@@ -95,24 +95,60 @@ def _maybe_optimize_image(url: str | None) -> tuple[str | None, dict | None]:
 # ─────────────────────────────────────────────────────────────────────
 # RSS parse → top N items
 # ─────────────────────────────────────────────────────────────────────
-def _verify_one(rss_url: str, n: int = N_LATEST) -> dict:
-    log.info("verify: %s", rss_url)
+def _discover_entries(rss_url: str, feed_kind: str, feed_config: str | None,
+                      n: int) -> tuple[list[dict], str | None, str]:
+    """Return (entries, error, feed_title) where entries is a list of
+    {title, link, published} dicts. Dispatches by feed_kind. RSS path
+    keeps the legacy feedparser shape (preserves bozo error reporting);
+    html_list/sitemap delegate to pipeline.scraper."""
+    if feed_kind == "rss":
+        try:
+            feed = feedparser.parse(rss_url)
+        except Exception as e:  # noqa: BLE001
+            return [], f"feedparser failed: {e}", ""
+        if feed.bozo and not getattr(feed, "entries", None):
+            return [], f"feed parse error: {feed.bozo_exception}", ""
+        out = []
+        for entry in feed.entries[:n]:
+            out.append({
+                "title": htmllib.unescape(getattr(entry, "title", "") or ""),
+                "link": (getattr(entry, "link", "") or "").strip(),
+                "published": (getattr(entry, "published", "")
+                              or getattr(entry, "updated", "") or ""),
+            })
+        return out, None, getattr(feed.feed, "title", "")
+
+    # html_list / sitemap
+    from .scraper import discover_article_urls
     try:
-        feed = feedparser.parse(rss_url)
+        items = discover_article_urls({
+            "rss_url": rss_url,
+            "feed_kind": feed_kind,
+            "feed_config": feed_config,
+        }, top_n=n)
     except Exception as e:  # noqa: BLE001
-        return {"rss_url": rss_url, "error": f"feedparser failed: {e}",
-                "items": []}
-    if feed.bozo and not getattr(feed, "entries", None):
-        return {"rss_url": rss_url,
-                "error": f"feed parse error: {feed.bozo_exception}",
-                "items": []}
+        return [], f"{feed_kind} discovery failed: {type(e).__name__}: {e}", ""
+    out = [{
+        "title": htmllib.unescape(i.get("title") or ""),
+        "link": i["url"].strip(),
+        "published": i.get("lastmod") or "",
+    } for i in items]
+    return out, None, ""  # listing pages have no canonical "feed title"
+
+
+def _verify_one(rss_url: str, n: int = N_LATEST,
+                feed_kind: str = "rss",
+                feed_config: str | None = None) -> dict:
+    log.info("verify: %s [%s]", rss_url, feed_kind)
+    entries, err, feed_title = _discover_entries(rss_url, feed_kind, feed_config, n)
+    if err:
+        return {"rss_url": rss_url, "feed_kind": feed_kind, "error": err, "items": []}
 
     items = []
-    for entry in feed.entries[:n]:
-        link = (getattr(entry, "link", "") or "").strip()
-        title = htmllib.unescape(getattr(entry, "title", "") or "")
-        published = (getattr(entry, "published", "")
-                     or getattr(entry, "updated", "") or "")
+    for entry in entries:
+        link = entry["link"]
+        title = entry["title"]
+        published = entry["published"]
         if not link:
             items.append({"title": title, "link": "", "published": published,
                           "error": "no link in feed item"})
@@ -132,7 +168,8 @@ def _verify_one(rss_url: str, n: int = N_LATEST) -> dict:
         })
     return {
         "rss_url": rss_url,
-        "feed_title": getattr(feed.feed, "title", ""),
+        "feed_kind": feed_kind,
+        "feed_title": feed_title,
         "fetched_at": datetime.now(timezone.utc).isoformat(timespec="seconds"),
         "items": items,
     }
@@ -277,6 +314,11 @@ def main():
     g.add_argument("--category", type=str)
     g.add_argument("--all", action="store_true")
     p.add_argument("--name", type=str, default="", help="display name when using --rss-url")
+    p.add_argument("--feed-kind", type=str, default="rss",
+                   choices=("rss", "sitemap", "html_list"),
+                   help="ad-hoc feed kind when using --rss-url (default: rss)")
+    p.add_argument("--feed-config", type=str, default=None,
+                   help="ad-hoc feed_config JSON when using --rss-url (e.g. '{\"article_selector\":\"...\"}')")
     p.add_argument("--out", type=Path, default=None, help="output directory (default: out/verify/<timestamp>/)")
     p.add_argument("--upload", action="store_true",
                    help="also upload to Supabase Storage at verify/<timestamp>/ (needs SUPABASE_*)")
@@ -286,10 +328,11 @@ def main():
     out_dir = args.out or Path("out") / "verify" / ts
     out_dir.mkdir(parents=True, exist_ok=True)
 
-    # (label, rss_url, source_id-or-None) per target.
-    targets_with_id: list[tuple[str, str, int | None]] = []
+    # (label, rss_url, source_id-or-None, feed_kind, feed_config) per target.
+    targets: list[tuple[str, str, int | None, str, str | None]] = []
     if args.rss_url:
-        targets_with_id.append((args.name or args.rss_url, args.rss_url, None))
+        targets.append((args.name or args.rss_url, args.rss_url, None,
+                        args.feed_kind, args.feed_config))
     else:
         rows = _load_sources(args.source_id, args.category, args.all)
         if not rows:
@@ -297,17 +340,18 @@ def main():
             sys.exit(2)
         for r in rows:
             label = f"{r.get('category','?')} · {r.get('name','?')}"
-            targets_with_id.append((label, r.get("rss_url") or "", r.get("id")))
+            targets.append((label, r.get("rss_url") or "", r.get("id"),
+                            r.get("feed_kind") or "rss", r.get("feed_config")))
 
-    log.info("verifying %d source(s) → %s", len(targets_with_id), out_dir)
+    log.info("verifying %d source(s) → %s", len(targets), out_dir)
     results: list[tuple[str, dict, Path]] = []
     successful_source_ids: list[int] = []  # rows whose verify produced usable extraction
 
-    for name, rss_url, src_id in targets_with_id:
+    for name, rss_url, src_id, feed_kind, feed_config in targets:
         if not rss_url:
             log.warning("skip (no rss_url): %s", name); continue
         t0 = time.monotonic()
-        res = _verify_one(rss_url)
+        res = _verify_one(rss_url, feed_kind=feed_kind, feed_config=feed_config)
         elapsed = time.monotonic() - t0
         log.info("  %s · %.1fs · %d items", name, elapsed, len(res.get("items") or []))
         html = _render_one(res, name)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 beautifulsoup4>=4.12
 feedparser>=6.0
+lxml>=5.0
 fpdf2>=2.7
 pillow>=10.3
 python-dotenv>=1.0

--- a/supabase/migrations/20260503_feed_kind_html_list.sql
+++ b/supabase/migrations/20260503_feed_kind_html_list.sql
@@ -1,0 +1,25 @@
+-- Add feed_kind + feed_config to redesign_source_configs.
+--
+-- Driver: sourcefinder is promoting non-RSS candidates (DOGOnews,
+-- NG Kids — Space, NG Kids — Geography). The current pipeline only
+-- knows RSS at fetch time; these need an HTML-listing-page selector.
+--
+-- See docs/HANDOVER-from-sourcefinder-html_list.md for the contract.
+--
+-- Backwards-compatible: every existing row defaults to feed_kind='rss',
+-- so behavior is unchanged for live sources.
+
+ALTER TABLE redesign_source_configs
+    ADD COLUMN IF NOT EXISTS feed_kind TEXT NOT NULL DEFAULT 'rss';
+
+ALTER TABLE redesign_source_configs
+    ADD COLUMN IF NOT EXISTS feed_config TEXT;  -- JSON; nullable for rss
+
+-- Lock the values feed_kind can take. Adding a new kind requires a
+-- migration AND a code update in pipeline/scraper.py:discover_article_urls.
+ALTER TABLE redesign_source_configs
+    DROP CONSTRAINT IF EXISTS redesign_source_configs_feed_kind_check;
+
+ALTER TABLE redesign_source_configs
+    ADD CONSTRAINT redesign_source_configs_feed_kind_check
+    CHECK (feed_kind IN ('rss', 'sitemap', 'html_list'));

--- a/supabase/migrations/20260503_zombie_runs_sweep.sql
+++ b/supabase/migrations/20260503_zombie_runs_sweep.sql
@@ -1,0 +1,41 @@
+-- Hourly sweep for zombie redesign_runs rows.
+--
+-- Problem: when the pipeline crashes via uncaught exception (RuntimeError
+-- in batch_vet) or SystemExit (pack_and_upload abort), the final
+-- "status='failed'" PATCH never runs. The row stays with status='running'
+-- and finished_at=NULL forever, polluting the dashboard.
+--
+-- Fix: sweep every hour. Anything still 'running' more than 90 minutes
+-- after started_at is dead — the pipeline timeout is 90 min, so a row
+-- past that window with no finished_at must have crashed.
+--
+-- Safe by construction: if a healthy run finishes in <90 min the row is
+-- already status='completed' before the sweep can touch it.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron;
+
+-- Idempotent: drop any prior version of this job, then re-add.
+DO $$
+DECLARE
+    j_id bigint;
+BEGIN
+    SELECT jobid INTO j_id FROM cron.job WHERE jobname = 'cleanup-zombie-runs';
+    IF j_id IS NOT NULL THEN
+        PERFORM cron.unschedule(j_id);
+    END IF;
+END$$;
+
+SELECT cron.schedule(
+    'cleanup-zombie-runs',
+    '0 * * * *',  -- every hour, on the hour
+    $sweep$
+        UPDATE redesign_runs
+        SET status = 'failed',
+            finished_at = NOW(),
+            notes = COALESCE(notes, '') ||
+                    ' (zombie sweep: pipeline crashed before final status write)'
+        WHERE status = 'running'
+          AND started_at < NOW() - INTERVAL '90 minutes'
+          AND finished_at IS NULL;
+    $sweep$
+);

--- a/supabase/seeds/2026-05-03-fun-html-list-sources.sql
+++ b/supabase/seeds/2026-05-03-fun-html-list-sources.sql
@@ -1,0 +1,58 @@
+-- Seed the 3 html_list candidates from sourcefinder into Fun category.
+--
+-- Inserted with enabled=false so they're staged but stay OUT of the
+-- pipeline rotation until PR #17 (feed_kind dispatcher) is merged
+-- and deployed. After merge, flip them on with:
+--
+--   UPDATE redesign_source_configs SET enabled = true
+--   WHERE category = 'Fun' AND feed_kind = 'html_list';
+--
+-- Empirical wordcounts (per docs/HANDOVER-from-sourcefinder-html_list.md):
+--   - DOGOnews: ~334 wc avg
+--   - NG Kids — Space: ~247 wc avg (some shorter)
+--   - NG Kids — Geography: ~682 wc avg
+
+INSERT INTO redesign_source_configs
+    (category, name, rss_url, feed_kind, feed_config,
+     flow, max_to_vet, min_body_words, priority,
+     enabled, is_backup, state, notes)
+VALUES
+    ('Fun', 'DOGOnews',
+     'https://www.dogonews.com/',
+     'html_list',
+     '{"article_selector": "article a[href*=\"/2026\"], article a[href*=\"/2025\"]", "exclude_pattern": "#comment"}',
+     'full', 10, 200, 6,
+     false, false, 'live',
+     'html_list source from sourcefinder 2026-05-03; flip enabled=true after PR #17 deploy'),
+
+    ('Fun', 'NG Kids — Space',
+     'https://kids.nationalgeographic.com/space/',
+     'html_list',
+     '{"article_selector": "a[href*=\"/space/\"][href*=\"/article/\"]"}',
+     'full', 10, 200, 7,
+     false, false, 'live',
+     'html_list source from sourcefinder 2026-05-03; min_body=200 (some pieces ~247 wc)'),
+
+    ('Fun', 'NG Kids — Geography',
+     'https://kids.nationalgeographic.com/geography/',
+     'html_list',
+     '{"article_selector": "a[href*=\"/geography/\"]", "exclude_pattern": "/games/|/videos/"}',
+     'full', 10, 300, 8,
+     false, false, 'live',
+     'html_list source from sourcefinder 2026-05-03; ~682 wc avg, comfortable margin');
+
+-- Verification: after running this seed, ensure 3 rows exist with feed_kind='html_list'
+-- in Fun, all enabled=false:
+--
+--   SELECT name, feed_kind, enabled, priority FROM redesign_source_configs
+--   WHERE category = 'Fun' AND feed_kind = 'html_list' ORDER BY priority;
+--
+-- After PR #17 merges + deploys, smoke-test ONE source first:
+--
+--   UPDATE redesign_source_configs SET enabled = true WHERE name = 'DOGOnews';
+--
+-- Watch the next pipeline run's logs for "[DOGOnews] Phase A: flow=full feed_kind=html_list"
+-- + "[DOGOnews]  entries: N" with N >= 3. If green, flip the other two:
+--
+--   UPDATE redesign_source_configs SET enabled = true
+--   WHERE category = 'Fun' AND feed_kind = 'html_list';


### PR DESCRIPTION
## Summary

- Adds `feed_kind` + `feed_config` columns to `redesign_source_configs` so non-RSS sources (HTML listing pages, sitemaps) can ship through the daily pipeline.
- Ports `scraper.py` from the `sourcefinder` repo verbatim (~297 lines) and adds a single `fetch_source_entries` dispatcher that routes by `feed_kind`. RSS path delegates to existing `fetch_rss_entries` — zero behavior change for the 19 live RSS sources.
- Cleaner (`pipeline/cleaner.py`) is **untouched** — body extraction is feed-kind-agnostic.

Driver: sourcefinder is about to promote DOGOnews + NG Kids — Space + NG Kids — Geography, all `html_list`. Without this PR they fail at fetch time.

Spec: `docs/HANDOVER-from-sourcefinder-html_list.md` (committed alongside).

## Schema migration (already applied)

```sql
ALTER TABLE redesign_source_configs
  ADD COLUMN feed_kind TEXT NOT NULL DEFAULT 'rss',
  ADD COLUMN feed_config TEXT;
-- + CHECK IN ('rss', 'sitemap', 'html_list')
```

19 existing rows backfilled to `'rss'`. Verified: `SELECT feed_kind, count(*) FROM redesign_source_configs GROUP BY 1;` → `rss=19`.

## Test plan

- [x] Offline unit-style smoke test: `python -m pipeline.test_scraper_html_list` — passes 3 assertions (extraction, dispatcher html_list, dispatcher rss-unchanged).
- [ ] Stage the 3 test rows from the handover doc with `enabled=false` once this merges, then a one-off `python -c` to confirm `fetch_source_entries(src)` returns ≥3 URLs each before flipping `enabled=true`.
- [ ] Next daily-pipeline run reports the same 9 stories (RSS path unchanged).
- [ ] After flipping the 3 new sources to `enabled=true`, confirm the new entries surface in the next aggregate phase.

## Coordination

Once merged, ping sourcefinder maintainer to update `bin/promote.py` to pass `feed_kind`/`feed_config` through (handover doc § 5).

🤖 Generated with [Claude Code](https://claude.com/claude-code)