### PR TITLE
feat(sources): auto-tune cadence_days from RSS publish-date gaps

### DIFF
--- a/pipeline/cadence_calibrate.py
+++ b/pipeline/cadence_calibrate.py
@@ -1,0 +1,194 @@
+"""Auto-tune `cadence_days` from observed RSS publish-date gaps.
+
+For each enabled RSS source in `redesign_source_configs`:
+  1. Fetch the feed
+  2. Pull up to 10 most-recent publish timestamps
+  3. Compute median gap between consecutive entries (days)
+  4. Round + clamp to [1, 30]
+  5. Update `cadence_days` (or dry-run report)
+
+Why median (not mean): a source that goes silent for 2 weeks then drops 5
+articles in a day has gaps like [10min, 10min, 10min, 14d]. Mean is ~3
+days; median is 10min → 1d. Median better reflects the source's typical
+cadence and resists outlier gaps from vacation / news-cycle spikes.
+
+Why clamp to [1, 30]:
+  - Daily-or-faster sources collapse to cadence=1 (we won't poll faster).
+  - Anything monthly+ collapses to 30 (we'll still poll monthly).
+  - Matches the CHECK constraint in 20260504_cadence_aware_sources.sql
+    (constraint allows up to 60; we choose a tighter ceiling here so a
+    once-yearly source doesn't sleep for a full year).
+
+Why RSS-only: html_list and sitemap sources don't carry uniform per-item
+publish dates. RSS does (`<pubDate>` / `<updated>`). For html_list
+sources, `cadence_days` stays manual — admin tunes it via Supabase
+Studio when adding the source.
+
+Run modes:
+  python -m pipeline.cadence_calibrate                 # dry-run report
+  python -m pipeline.cadence_calibrate --apply         # write back to DB
+  python -m pipeline.cadence_calibrate --source-id 321 # one source only
+  python -m pipeline.cadence_calibrate --apply --source-id 321
+"""
+from __future__ import annotations
+
+import argparse
+import logging
+import statistics
+import sys
+import time
+from typing import Iterable
+
+import feedparser
+
+from .supabase_io import client
+
+log = logging.getLogger("cadence-calibrate")
+
+CADENCE_MIN = 1
+CADENCE_MAX = 30
+PUB_DATES_PER_SOURCE = 10
+MIN_GAPS_REQUIRED = 2  # need ≥ 2 gaps (3 entries) to compute a meaningful median
+
+
+def fetch_pub_timestamps(rss_url: str,
+                         n: int = PUB_DATES_PER_SOURCE) -> list[float]:
+    """Pull up to `n` publish timestamps (unix seconds, newest first)
+    from an RSS feed. Returns [] on parse error or empty feed."""
+    try:
+        feed = feedparser.parse(rss_url)
+    except Exception as e:  # noqa: BLE001 — feedparser can throw a variety
+        log.warning("feedparser failed on %s: %s", rss_url[:60], e)
+        return []
+    out: list[float] = []
+    for entry in feed.entries[:n]:
+        ts = getattr(entry, "published_parsed", None) \
+             or getattr(entry, "updated_parsed", None)
+        if ts:
+            try:
+                out.append(time.mktime(ts))
+            except (OverflowError, ValueError):
+                continue
+    out.sort(reverse=True)
+    return out
+
+
+def compute_cadence_days(pub_dates: list[float]) -> int | None:
+    """Median consecutive-entry gap in days, clamped to [1, 30].
+
+    Returns None when fewer than `MIN_GAPS_REQUIRED + 1` valid timestamps
+    are available (e.g. brand-new feed, parse failure, all entries dateless)."""
+    if len(pub_dates) < MIN_GAPS_REQUIRED + 1:
+        return None
+    # pub_dates is sorted newest-first; gaps are always positive.
+    gaps_seconds = [pub_dates[i] - pub_dates[i + 1]
+                    for i in range(len(pub_dates) - 1)
+                    if pub_dates[i] > pub_dates[i + 1]]
+    if len(gaps_seconds) < MIN_GAPS_REQUIRED:
+        return None
+    median_gap_days = statistics.median(gaps_seconds) / 86400.0
+    return max(CADENCE_MIN, min(CADENCE_MAX, round(median_gap_days)))
+
+
+def _load_sources(source_id: int | None) -> list[dict]:
+    sb = client()
+    q = sb.table("redesign_source_configs").select(
+        "id,name,category,rss_url,feed_kind,cadence_days,enabled"
+    ).eq("enabled", True)
+    if source_id is not None:
+        q = q.eq("id", source_id)
+    res = q.execute()
+    return list(res.data or [])
+
+
+def _persist_cadence(source_id: int, new_cadence: int) -> None:
+    sb = client()
+    sb.table("redesign_source_configs") \
+        .update({"cadence_days": new_cadence}) \
+        .eq("id", source_id) \
+        .execute()
+
+
+def calibrate(*, dry_run: bool = True,
+              source_id: int | None = None) -> list[tuple]:
+    """Run the calibration. Returns a report rows list of
+    (name, old_cadence, new_cadence_or_None, status)."""
+    rows = _load_sources(source_id)
+    report: list[tuple] = []
+
+    for r in rows:
+        name = r.get("name") or f"id={r.get('id')}"
+        old = int(r.get("cadence_days") or 1)
+        feed_kind = (r.get("feed_kind") or "rss").lower()
+
+        if feed_kind != "rss":
+            report.append((name, old, None, f"skipped ({feed_kind})"))
+            continue
+
+        rss_url = r.get("rss_url")
+        if not rss_url:
+            report.append((name, old, None, "skipped (no rss_url)"))
+            continue
+
+        pub = fetch_pub_timestamps(rss_url)
+        new = compute_cadence_days(pub)
+        if new is None:
+            report.append((name, old, None,
+                           f"insufficient data ({len(pub)} dates)"))
+            continue
+
+        if new == old:
+            report.append((name, old, new, "no change"))
+            continue
+
+        if dry_run:
+            report.append((name, old, new, "would update"))
+        else:
+            try:
+                _persist_cadence(int(r["id"]), new)
+                report.append((name, old, new, "updated"))
+            except Exception as e:  # noqa: BLE001
+                report.append((name, old, new, f"WRITE FAILED: {e}"))
+
+    return report
+
+
+def _print_report(report: list[tuple]) -> None:
+    print(f"\n{'Source':<36}{'Old':>5}{'New':>5}  Status")
+    print("-" * 78)
+    for name, old, new, status in report:
+        n_disp = name[:35]
+        new_s = str(new) if new is not None else "—"
+        print(f"{n_disp:<36}{old:>5}{new_s:>5}  {status}")
+
+    changed = sum(1 for _, _, _, s in report if "updated" in s or "would" in s)
+    skipped = sum(1 for _, _, _, s in report if "skipped" in s or "insufficient" in s)
+    nochange = sum(1 for _, _, _, s in report if s == "no change")
+    failed = sum(1 for _, _, _, s in report if "FAILED" in s)
+    print(f"\n{len(report)} sources · {changed} changed · {nochange} no-change "
+          f"· {skipped} skipped · {failed} failed")
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO,
+                        format="%(asctime)s %(levelname)s %(message)s")
+    p = argparse.ArgumentParser(description=__doc__.split("\n\n")[0])
+    p.add_argument("--apply", action="store_true",
+                   help="Write back to DB. Default: dry-run.")
+    p.add_argument("--source-id", type=int, default=None,
+                   help="Calibrate only this source row id.")
+    args = p.parse_args()
+
+    mode = "APPLY (writing to DB)" if args.apply else "DRY RUN (no DB writes)"
+    print(f"Cadence calibration — {mode}")
+    print(f"Sources: {'id=' + str(args.source_id) if args.source_id else 'all enabled'}")
+    print(f"Window:  last {PUB_DATES_PER_SOURCE} entries per RSS feed")
+    print(f"Bounds:  [{CADENCE_MIN}, {CADENCE_MAX}] days (median gap)")
+
+    report = calibrate(dry_run=not args.apply, source_id=args.source_id)
+    _print_report(report)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/pipeline/test_cadence_calibrate.py
+++ b/pipeline/test_cadence_calibrate.py
@@ -1,0 +1,108 @@
+"""Offline tests for compute_cadence_days — the median-gap math.
+
+Run: python -m pipeline.test_cadence_calibrate
+
+No network, no DB. Tests the pure compute function with synthetic
+timestamps. The fetch path is exercised end-to-end via the production
+calibrate() call which is integration-tested by manual dry-run.
+"""
+from __future__ import annotations
+
+import sys
+
+from .cadence_calibrate import compute_cadence_days
+
+
+# Helper: build a list of timestamps representing entries at given day
+# offsets from now, newest-first (matches fetch_pub_timestamps shape).
+DAY = 86400.0
+
+
+def days_ago(*offsets: float) -> list[float]:
+    """E.g. days_ago(0, 1, 2) → 3 entries spanning today, yesterday, day-before."""
+    base = 1_000_000_000.0  # arbitrary epoch baseline
+    return sorted([base - off * DAY for off in offsets], reverse=True)
+
+
+def test_daily_source():
+    """Every day for 5 days → cadence=1."""
+    pub = days_ago(0, 1, 2, 3, 4)
+    assert compute_cadence_days(pub) == 1, compute_cadence_days(pub)
+    print("PASS: daily source → cadence=1")
+
+
+def test_weekly_source():
+    """Once a week for 5 weeks → cadence=7."""
+    pub = days_ago(0, 7, 14, 21, 28)
+    assert compute_cadence_days(pub) == 7, compute_cadence_days(pub)
+    print("PASS: weekly source → cadence=7")
+
+
+def test_burst_publishing_clamps_to_1():
+    """5 entries published 10 minutes apart → median gap < 1d, clamped to 1."""
+    pub = days_ago(0, 0.007, 0.014, 0.020, 0.028)  # roughly 10-min gaps
+    assert compute_cadence_days(pub) == 1, compute_cadence_days(pub)
+    print("PASS: burst-publishing → cadence=1 (clamped)")
+
+
+def test_monthly_clamps_to_30():
+    """Three entries 60 days apart → cadence=30 (clamped from 60)."""
+    pub = days_ago(0, 60, 120, 180)
+    assert compute_cadence_days(pub) == 30, compute_cadence_days(pub)
+    print("PASS: monthly+ source → cadence=30 (clamped)")
+
+
+def test_irregular_uses_median_not_mean():
+    """Gaps: 1d, 1d, 30d. Mean=10.7d, median=1d. Confirm median wins."""
+    pub = days_ago(0, 1, 2, 32)
+    assert compute_cadence_days(pub) == 1, compute_cadence_days(pub)
+    print("PASS: irregular gaps use median (resists outliers)")
+
+
+def test_too_few_entries_returns_none():
+    assert compute_cadence_days([]) is None
+    assert compute_cadence_days([1_000_000_000.0]) is None
+    assert compute_cadence_days([1_000_000_000.0, 999_999_900.0]) is None
+    print("PASS: ≤2 entries returns None (need ≥3 for ≥2 gaps)")
+
+
+def test_three_entries_minimum():
+    """Exactly 3 entries with consistent gap → reports the gap."""
+    pub = days_ago(0, 4, 8)  # gaps of 4d and 4d
+    assert compute_cadence_days(pub) == 4, compute_cadence_days(pub)
+    print("PASS: 3-entry minimum produces a cadence")
+
+
+def test_zero_gap_skipped():
+    """Two entries published at same instant (rare) → that gap is dropped;
+    if enough OTHER gaps remain, cadence still computes."""
+    # 4 entries: today, today, 3d-ago, 6d-ago.
+    # Raw gaps: 0, 3d, 3d. Filter the 0-gap dup → 3d, 3d. Median = 3d.
+    pub = days_ago(0, 0, 3, 6)
+    assert compute_cadence_days(pub) == 3, compute_cadence_days(pub)
+    print("PASS: zero-gap dups filtered, remaining gaps still produce cadence")
+
+
+def main() -> int:
+    tests = [
+        test_daily_source,
+        test_weekly_source,
+        test_burst_publishing_clamps_to_1,
+        test_monthly_clamps_to_30,
+        test_irregular_uses_median_not_mean,
+        test_too_few_entries_returns_none,
+        test_three_entries_minimum,
+        test_zero_gap_skipped,
+    ]
+    try:
+        for t in tests:
+            t()
+    except AssertionError as e:
+        print(f"FAIL: {e}", file=sys.stderr)
+        return 1
+    print(f"\nAll {len(tests)} tests passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary

Implements the v1.1 auto-tune from `docs/superpowers/specs/2026-05-03-cadence-aware-source-selection-design.md` (deferred from PR #18 to keep that change small).

For each enabled RSS source in `redesign_source_configs`:
1. Fetch up to 10 most-recent publish timestamps via `feedparser`.
2. Compute median consecutive-entry gap in days.
3. Round + clamp to `[1, 30]`.
4. Update `cadence_days` (or dry-run report).

### Why median, not mean

A source that goes silent 2 weeks then drops 5 articles in a day has gaps like `[10min, 10min, 10min, 14d]`. Mean is ~3 days; median is ~10min → cadence=1. Median better reflects the source's typical rhythm and resists outlier gaps from vacation / news-cycle spikes.

### Why RSS-only (skips html_list / sitemap)

RSS feeds carry `<pubDate>` / `<updated>` reliably. html_list listing pages don't have uniform per-item dates — auto-tuning them would need per-article HTML fetching (10 fetches per source per cron run, expensive). Manual cadence stays for those.

### Run modes

```bash
python -m pipeline.cadence_calibrate              # dry-run report (default)
python -m pipeline.cadence_calibrate --apply      # write back to DB
python -m pipeline.cadence_calibrate --source-id 321 --apply
```

### Test plan

- [x] `python -m pipeline.test_cadence_calibrate` — 8 cases pass (daily / weekly / burst / monthly / outliers / too-few / dups / 3-entry minimum)
- [ ] Live dry-run on prod: `python -m pipeline.cadence_calibrate` shows current vs proposed cadences for the 39 seeded sources.
- [ ] After PR #18 merges + this PR merges: weekly GH Actions cron triggers `--apply` on Mondays. (Cron yaml NOT in this PR — separate small follow-up.)

### Depends on

- PR #18 (cadence-aware sources) needs to merge first — provides the `cadence_days` column this PR writes to.

🤖 Generated with [Claude Code](https://claude.com/claude-code)