### PR TITLE
chore(ci): one post-publish quality email/day (drop duplicate cron)

### DIFF
--- a/.github/workflows/quality-digest.yml
+++ b/.github/workflows/quality-digest.yml
@@ -25,8 +25,11 @@ on:
   workflow_run:
     workflows: ["Daily pipeline"]
     types: [completed]
-  schedule:
-    - cron: "30 5 * * *"
+  # Removed the standalone `schedule: 30 5 * * *` (2026-07-08) — it sent a
+  # SECOND, duplicate quality-digest every day on top of the post-publish
+  # one. The workflow_run trigger above fires on every pipeline completion
+  # (success OR failure), so the quality report still goes out exactly once,
+  # right after publish. Net: one fewer email/day.
   workflow_dispatch:
     inputs:
       skip_sleep:


### PR DESCRIPTION
The quality digest was sent **twice a day** (post-publish workflow_run + a standalone 05:30 cron). Removed the standalone schedule → sent **once, right after publish**. With #27 stopping the false-failure watchdog alerts, this takes the owner from ~4-5 emails/day to **1-2** (quality report + parent digest).

Backend-only (workflow config). No effect on the site or the pipeline itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)