### PR TITLE
[DRAFT/review] security: close send-email-v2 open relay + magic-link token exposure

### DIFF
--- a/docs/superpowers/specs/2026-07-08-email-security-hardening.md
+++ b/docs/superpowers/specs/2026-07-08-email-security-hardening.md
@@ -1,0 +1,83 @@
+# Email security hardening — send-email-v2 open relay + magic-link token exposure
+
+**Status:** code drafted, NOT deployed — awaiting owner review.
+**Owner constraint:** the live site must not be affected. This spec's rollout
+order guarantees zero downtime for login and digests.
+
+## The two holes
+
+1. **`send-email-v2` is an open relay.** `verify_jwt=false`, no secret check.
+   Anyone can POST `{to_email, subject, html, from_name}` and send arbitrary
+   mail from the project's Gmail, with a spoofable sender display name →
+   phishing/spam from your domain, Gmail suspension, reputation loss.
+2. **Magic-link token handed to the browser.** `kidsync.js` called
+   `issue_magic_link` and got the raw token client-side, then emailed it via
+   the open relay. So anyone can mint + consume a link for any email without
+   inbox access.
+
+The client uses `send-email-v2` for THREE email types today (all let the
+browser control recipient + HTML + sender):
+- `kidsync.js` — kid magic-link sign-in.
+- `parent.jsx:588` — parent "email me the reading report".
+- `parent.jsx:1005` — parent "email the kid's recovery code".
+
+## Principle
+
+The browser must never control `to_email` + `html` + `from_name`. Each email
+type gets a purpose-built server function that composes the body server-side;
+`send-email-v2` becomes an internal, secret-gated SMTP relay.
+
+## Pieces (in this PR)
+
+- `supabase/functions/request-magic-link/index.ts` — NEW. Takes `{email,
+  client_id}`, issues the token server-side (never returns it), composes the
+  sign-in email, forwards to send-email-v2 with the secret. Replaces the
+  kid magic-link path.
+- `supabase/functions/send-email-v2/index.ts` — hardened: requires
+  `x-internal-secret == SEND_EMAIL_SECRET`, else 403. (This repo now holds the
+  source; previously it lived only on Supabase.)
+
+## Pieces (follow-up, described here — build when rolling out)
+
+- `send-recovery-code` edge fn (verify_jwt=true): takes `{kid_client_id}`,
+  reads the caller's email from the JWT, composes + sends. Replaces
+  `parent.jsx:1005`.
+- `send-parent-digest` edge fn (verify_jwt=true): composes the digest
+  server-side from the caller's kid data, sends to the JWT email. Replaces
+  `parent.jsx:588` (recipient stops being client-controlled).
+- Client edits: `kidsync.js` → call `request-magic-link`; `parent.jsx` → call
+  the two new functions. Remove all direct `send-email-v2` fetches.
+- Server callers add the secret header: `pipeline/quality_digest.py`,
+  `supabase/functions/send-digest/index.ts`, `.github/workflows/pipeline-watchdog.yml`.
+
+## Zero-downtime rollout order (CRITICAL)
+
+send-email-v2's lockdown is deployed LAST, only after every caller passes the
+secret — so there is never a window where a legit caller is rejected.
+
+1. Create the secret: `SEND_EMAIL_SECRET` (Supabase project secret) — a random
+   32+ char string. Set it on the project so all edge fns + the GH secret.
+2. Deploy `request-magic-link` (+ the two parent functions). Additive — nothing
+   else changes yet. send-email-v2 still open, so they work.
+3. Ship the client (kidsync.js + parent.jsx) pointing at the new functions.
+   Site deploy. Now no browser calls send-email-v2 directly.
+4. Update the 3 server callers to send `x-internal-secret`. Deploy them.
+   (Harmless extra header while send-email-v2 is still open.)
+5. Deploy the hardened `send-email-v2` (requires the secret). Now every caller
+   passes it → relay closed, zero breakage.
+
+## Verification per phase
+
+- After 2: `curl request-magic-link` with a test email → 200 + email arrives;
+  token never in the response.
+- After 3: real kid + parent sign-in still work (magic link, recovery, digest).
+- After 5: `curl send-email-v2` WITHOUT the secret → 403; WITH → 200. Digests
+  + login still work end-to-end.
+
+## Notes
+
+- Magic-link *binding* (requester vs clicker device) is already fixed and live
+  (PR #33 / `2026-07-08-magic-link-binds-clicking-device.md`).
+- `request-magic-link` stays verify_jwt=false (kids are anonymous); abuse is
+  capped by issue_magic_link's 5-active-links-per-email limit. Consider adding
+  a per-IP rate limit at rollout.

--- a/supabase/functions/request-magic-link/index.ts
+++ b/supabase/functions/request-magic-link/index.ts
@@ -1,0 +1,123 @@
+// request-magic-link — server-side magic-link sign-in email.
+//
+// WHY THIS EXISTS (security):
+//   The client used to (a) call issue_magic_link and receive the RAW token
+//   in the browser, then (b) POST arbitrary {to_email, subject, html,
+//   from_name} to the OPEN relay send-email-v2. That let anyone mint+consume
+//   a link for any email (token handed to any anon caller) AND send arbitrary
+//   mail from the project's Gmail (spoofable from_name).
+//
+//   This function moves BOTH server-side: it issues the token (never returns
+//   it), composes the email itself, and forwards to send-email-v2 WITH the
+//   shared secret. The browser only sends {email, client_id} and never sees a
+//   token or controls the email body/sender.
+//
+// It stays verify_jwt=false (kids aren't authenticated), but the abuse
+// surface is limited to "send a sign-in link to the given address", and
+// issue_magic_link already caps 5 active links per email.
+//
+// Bug: docs/superpowers/specs/2026-07-08-email-security-hardening.md
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+
+const SUPABASE_URL = Deno.env.get("SUPABASE_URL")!;
+const SERVICE_KEY =
+  Deno.env.get("SUPABASE_SERVICE_ROLE_KEY") || Deno.env.get("SUPABASE_SERVICE_KEY")!;
+const SEND_EMAIL_SECRET = Deno.env.get("SEND_EMAIL_SECRET") || "";
+
+const CORS = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, apikey, content-type",
+  "Access-Control-Allow-Methods": "POST, OPTIONS",
+};
+
+function json(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { ...CORS, "Content-Type": "application/json" },
+  });
+}
+
+const sb = createClient(SUPABASE_URL, SERVICE_KEY, {
+  auth: { persistSession: false, autoRefreshToken: false },
+});
+
+function signinEmailHtml(link: string): string {
+  return (
+    '<div style="font-family:-apple-system,Segoe UI,Roboto,sans-serif;background:#fff9ef;padding:24px;color:#1b1230;">' +
+    '<h2 style="font-family:Georgia,serif;margin:0 0 12px;font-weight:900;">Sign in to kidsnews</h2>' +
+    '<p style="font-size:14px;color:#3a2a4a;line-height:1.5;">' +
+    "Tap the button below to sync your reading streak to this email. After this, you can come back from any browser.</p>" +
+    '<div style="margin:18px 0;"><a href="' + link + '" ' +
+    'style="display:inline-block;background:#1b1230;color:#ffc83d;font-family:Nunito,sans-serif;font-weight:900;' +
+    'font-size:15px;padding:14px 22px;border-radius:14px;text-decoration:none;border:2px solid #1b1230;">' +
+    "✨ Sync this email to kidsnews</a></div>" +
+    '<p style="font-size:12px;color:#9a8d7a;line-height:1.5;">' +
+    "This link is single-use and expires in 30 minutes. If you didn't ask for this, ignore this email.</p></div>"
+  );
+}
+
+Deno.serve(async (req: Request): Promise<Response> => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: CORS });
+  if (req.method !== "POST") return json(405, { error: "POST only" });
+
+  if (!SEND_EMAIL_SECRET) {
+    return json(500, { error: "SEND_EMAIL_SECRET not configured" });
+  }
+
+  let email = "";
+  let clientId: string | null = null;
+  try {
+    const body = await req.json();
+    email = String(body.email || "").trim().toLowerCase();
+    clientId = body.client_id ? String(body.client_id) : null;
+  } catch {
+    return json(400, { error: "Invalid JSON body" });
+  }
+  if (!email || email.indexOf("@") < 1 || email.length > 320) {
+    return json(400, { error: "Please enter a valid email." });
+  }
+
+  // 1. Issue the token server-side (bound to the REQUESTING device). The
+  //    token is NEVER returned to the caller.
+  const { data: token, error: issueErr } = await sb.rpc("issue_magic_link", {
+    p_email: email,
+    p_client_id: clientId,
+  });
+  if (issueErr || !token) {
+    // issue_magic_link raises "Too many pending links..." past 5 active.
+    const msg = issueErr?.message || "Could not create a sign-in link.";
+    const status = /too many/i.test(msg) ? 429 : 500;
+    return json(status, { error: msg });
+  }
+
+  // 2. Compose the sign-in email server-side and send via the (now
+  //    secret-gated) relay. The origin comes from the request so the link
+  //    points back at the site the user is on.
+  const origin = req.headers.get("origin") || "https://kidsnews.21mins.com";
+  const link = `${origin}/?magic=${encodeURIComponent(String(token))}`;
+  const html = signinEmailHtml(link);
+  const text =
+    "Sign in to kidsnews\n\nTap to sync this email to your reading streak:\n" +
+    link + "\n\n(Single-use, expires in 30 minutes. Ignore if you didn't ask for this.)";
+
+  const relay = await fetch(`${SUPABASE_URL}/functions/v1/send-email-v2`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", "x-internal-secret": SEND_EMAIL_SECRET },
+    body: JSON.stringify({
+      to_email: email,
+      subject: "Your kidsnews sign-in link",
+      html,
+      message: text,
+      from_name: "kidsnews",
+    }),
+  });
+  if (!relay.ok) {
+    const detail = await relay.text().catch(() => "");
+    console.error("send-email-v2 failed:", relay.status, detail.slice(0, 200));
+    return json(502, { error: "Could not send the sign-in email. Try again shortly." });
+  }
+
+  // Success — no token, no internal detail leaks to the browser.
+  return json(200, { success: true });
+});

--- a/supabase/functions/send-email-v2/index.ts
+++ b/supabase/functions/send-email-v2/index.ts
@@ -1,0 +1,94 @@
+// send-email-v2 — internal SMTP relay (Gmail). HARDENED 2026-07-08.
+//
+// This function was an OPEN RELAY: verify_jwt=false with no auth, so anyone
+// could POST {to_email, subject, html, from_name} and send arbitrary mail
+// from the project's Gmail (spoofable sender name) to any recipient.
+//
+// It is now INTERNAL-ONLY: callers must present the shared secret in the
+// `x-internal-secret` header (checked in constant-ish time against
+// SEND_EMAIL_SECRET). Legitimate callers are all server-side:
+//   · request-magic-link (kid sign-in)         · send-recovery-code
+//   · send-parent-digest                         · send-digest
+//   · quality_digest.py                          · pipeline-watchdog.yml
+// The browser no longer calls this directly.
+//
+// ROLLOUT NOTE: deploy this LAST (after every caller passes the secret) — see
+// docs/superpowers/specs/2026-07-08-email-security-hardening.md. Deploying it
+// before the callers are updated would break outbound email.
+
+import { createClient } from "https://esm.sh/@supabase/supabase-js@2";
+import { SMTPClient } from "https://deno.land/x/denomailer@1.6.0/mod.ts";
+
+const corsHeaders = {
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Headers": "authorization, x-client-info, apikey, content-type, x-internal-secret",
+};
+
+const SEND_EMAIL_SECRET = Deno.env.get("SEND_EMAIL_SECRET") || "";
+
+function timingSafeEqual(a: string, b: string): boolean {
+  if (a.length !== b.length || a.length === 0) return false;
+  let diff = 0;
+  for (let i = 0; i < a.length; i++) diff |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  return diff === 0;
+}
+
+function htmlToText(html: string): string {
+  return html
+    .replace(/<style[\s\S]*?<\/style>/gi, "")
+    .replace(/<script[\s\S]*?<\/script>/gi, "")
+    .replace(/<br\s*\/?>/gi, "\n")
+    .replace(/<\/(p|div|h[1-6]|li|tr|td|th)>/gi, "\n")
+    .replace(/<a[^>]*href="([^"]+)"[^>]*>([^<]+)<\/a>/gi, "$2 ($1)")
+    .replace(/<[^>]+>/g, "")
+    .replace(/&nbsp;/g, " ").replace(/&amp;/g, "&").replace(/&lt;/g, "<")
+    .replace(/&gt;/g, ">").replace(/&quot;/g, '"').replace(/&#39;/g, "'")
+    .replace(/[ \t]+\n/g, "\n").replace(/\n{3,}/g, "\n\n").trim();
+}
+
+Deno.serve(async (req: Request) => {
+  if (req.method === "OPTIONS") return new Response("ok", { headers: corsHeaders });
+  try {
+    // ── AUTH GATE (new) ──
+    if (!SEND_EMAIL_SECRET) {
+      return new Response(JSON.stringify({ error: "relay not configured" }), {
+        status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    if (!timingSafeEqual(req.headers.get("x-internal-secret") || "", SEND_EMAIL_SECRET)) {
+      return new Response(JSON.stringify({ error: "forbidden" }), {
+        status: 403, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+
+    const { to_email, subject, message, html, from_name } = await req.json();
+    if (!to_email || !subject || (!message && !html)) {
+      return new Response(JSON.stringify({ error: "Missing: to_email, subject, message/html" }), {
+        status: 400, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    const sc = createClient(Deno.env.get("SUPABASE_URL")!, Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!);
+    const { data: gmailAddr } = await sc.rpc("get_secret", { secret_name: "GMAIL_ADDRESS" });
+    const { data: gmailPass } = await sc.rpc("get_secret", { secret_name: "GMAIL_APP_PASSWORD" });
+    if (!gmailAddr || !gmailPass) {
+      return new Response(JSON.stringify({ error: "Gmail not configured" }), {
+        status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+      });
+    }
+    const senderName = from_name || "kidsnews";
+    const client = new SMTPClient({
+      connection: { hostname: "smtp.gmail.com", port: 465, tls: true, auth: { username: gmailAddr, password: gmailPass } },
+    });
+    const textContent = message || (html ? htmlToText(html) : "");
+    await client.send({ from: `${senderName} <${gmailAddr}>`, to: to_email, subject, content: textContent, html: html || undefined });
+    await client.close();
+    return new Response(JSON.stringify({ success: true, message: `Email sent to ${to_email}`, from: senderName }), {
+      status: 200, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  } catch (e) {
+    console.error("Send email error:", e);
+    return new Response(JSON.stringify({ error: (e as Error).message }), {
+      status: 500, headers: { ...corsHeaders, "Content-Type": "application/json" },
+    });
+  }
+});


### PR DESCRIPTION
> **DRAFT — do not merge/deploy without review.** Left un-deployed on purpose (per "don't affect the live site" while you were away). Edge-function deploys are manual, so this can sit safely.

## Holes
1. `send-email-v2` was an **open email relay** (no auth) — anyone could send arbitrary mail from your Gmail with a spoofable sender.
2. Magic-link **token handed to the browser** — anyone could mint+consume a link for any email.

## In this PR
- `request-magic-link` (new): issues the token server-side (never returns it), composes the sign-in email, forwards to send-email-v2 with the shared secret.
- `send-email-v2` (hardened): requires `x-internal-secret`; 403 otherwise. Source now lives in-repo.
- Design doc with the **zero-downtime rollout order** (deploy the lockdown LAST, after all callers pass the secret) + the follow-up pieces (parent recovery/digest server functions, client edits, server-caller secret headers).

## Why draft
This is a 5-phase production email/auth change. It should roll out **in order, with verification at each step, while you can watch it** — not unattended. When you're ready, I'll execute the phases and verify each.

🤖 Generated with [Claude Code](https://claude.com/claude-code)