### PR TITLE
fix(pipeline): reject missing/generic images (image quality first)

### DIFF
--- a/docs/bugs/2026-07-08-news-safety-and-image-tuning.md
+++ b/docs/bugs/2026-07-08-news-safety-and-image-tuning.md
@@ -68,3 +68,14 @@ article for its image; never ship the generic branding image.
   these thresholds are applied to.
 - Follow-up: real per-category placeholder art (nicer than a plain colour card);
   extracting a real in-body image for NPR instead of clearing.
+
+## Update (same day) — image policy reverted to REJECT
+
+Owner decision: image quality matters more than article count — if the image
+is wrong/missing, REJECT the article rather than ship a blank category-colour
+card. `verify_article_content` is back to rejecting on missing/generic image.
+This is affordable because the per-dimension safety loosening (kept) lets
+real-image hard-news sources (PBS/BBC/Al Jazeera) through, so News fills from
+good-image articles. Residual thin-News risk remains → durable fix is more
+News sources and/or extracting a real in-body image for NPR.
+Tests: test_missing_image_rejected, test_generic_image_rejected, test_real_image_kept.

--- a/pipeline/news_rss_core.py
+++ b/pipeline/news_rss_core.py
@@ -1799,17 +1799,18 @@ def verify_article_content(art: dict) -> tuple[bool, str | None]:
         return False, f"body {wc}w < {MIN_PICK_BODY_WORDS}w"
     if wc > MAX_PICK_BODY_WORDS:
         return False, f"body {wc}w > {MAX_PICK_BODY_WORDS}w (suspect aggregate page)"
-    # Image is OPTIONAL — never a reason to drop a kid-safe article, and we
-    # never ship an ugly generic branding image (e.g. NPR's facebook-default,
-    # which showed the NPR logo instead of a real photo). A missing OR generic
-    # image is CLEARED (set to None): the article ships image-less and the
-    # frontend renders a clean category-colour card (home.jsx:
-    # `s.image ? url(...) : c.color`); process_images() skips a null og_image
-    # (guarded at full_round.py `if not og: continue`). Dropping on image
-    # starved thin categories (News collapsed to 1 on 2026-07-08).
-    # Bug: docs/bugs/2026-07-08-news-image-drop-starves-supply.md
-    if not art.get("og_image") or is_generic_social_image(art.get("og_image")):
-        art["og_image"] = None
+    # A real, relevant photo matters (owner choice 2026-07-08): REJECT an
+    # article whose image is missing or a generic social default (e.g. NPR's
+    # facebook-default logo) rather than ship a wrong/blank card. This is
+    # affordable now because the per-dimension safety loosening lets hard-news
+    # sources with REAL photos (PBS, BBC, Al Jazeera) through, so News stays
+    # filled without accepting bad images. (Order: the missing check first —
+    # is_generic_social_image(None) is True, so it would otherwise misreport.)
+    # Bug: docs/bugs/2026-07-08-news-safety-and-image-tuning.md
+    if not art.get("og_image"):
+        return False, "no og:image"
+    if is_generic_social_image(art.get("og_image")):
+        return False, f"generic social image: {art.get('og_image')}"
     return True, None
 
 

--- a/pipeline/test_filter_polish.py
+++ b/pipeline/test_filter_polish.py
@@ -38,26 +38,24 @@ def test_real_slang_and_editorial_choices_still_forbidden():
     assert is_forbidden("betting on the game")[0] is True           # ditto — deliberately kept
 
 
-# ── 2. image is optional: keep the article, clear a missing/generic image ──
+# ── 2. image quality: reject a missing/generic image, keep a real one ──
 
-def test_missing_image_kept_and_cleared():
-    # 2026-07-08: a missing image is no longer a reason to drop — keep the
-    # article, ship image-less (frontend renders a category-colour card).
+def test_missing_image_rejected():
+    # Owner choice (2026-07-08): a real photo matters — reject rather than ship
+    # a blank/wrong card. Missing image → reject, honest reason.
     art = {"word_count": (core.MIN_PICK_BODY_WORDS + core.MAX_PICK_BODY_WORDS) // 2,
            "og_image": None}
     ok, reason = core.verify_article_content(art)
-    assert ok is True and reason is None
-    assert art["og_image"] is None
+    assert ok is False and reason == "no og:image"
 
 
-def test_generic_image_cleared_not_shipped():
-    # A generic NPR facebook-default image is CLEARED (not shipped as the
-    # article photo) — the article is kept but rendered as a colour card.
+def test_generic_image_rejected():
+    # NPR's facebook-default (generic branding) image → reject (don't ship the
+    # wrong photo). The safety loosening keeps News filled from real-image sources.
     art = {"word_count": (core.MIN_PICK_BODY_WORDS + core.MAX_PICK_BODY_WORDS) // 2,
            "og_image": "https://media.npr.org/include/images/facebook-default-wide.jpg"}
     ok, reason = core.verify_article_content(art)
-    assert ok is True and reason is None
-    assert art["og_image"] is None          # generic image cleared, not shipped
+    assert ok is False and "generic social image" in reason
 
 
 def test_real_image_kept():
@@ -65,7 +63,6 @@ def test_real_image_kept():
            "og_image": "https://example.com/real-article-photo.jpg"}
     ok, reason = core.verify_article_content(art)
     assert ok is True and reason is None
-    assert art["og_image"] == "https://example.com/real-article-photo.jpg"
 
 
 # ── 3. cadence estimator ──


### PR DESCRIPTION
Owner choice: a real photo matters — reject an article whose image is missing or a generic social default (NPR facebook-default logo) rather than ship a blank card. Reverses the clear-to-colour-card approach. Affordable now because the per-dimension safety loosening (kept, #37) lets real-image hard-news sources (PBS/BBC/Al Jazeera) through, so News fills from good-image articles. Tests updated + green. Backend-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)