### PR TITLE
fix(pipeline): probe cap starved BBC — interleave sources + per-source funnel telemetry

### DIFF
--- a/docs/bugs/2026-07-08-probe-cap-starves-low-priority-sources.md
+++ b/docs/bugs/2026-07-08-probe-cap-starves-low-priority-sources.md
@@ -1,0 +1,74 @@
+# 2026-07-08 — probe cap starves low-priority sources (BBC never reached curator)
+
+**Severity:** medium
+**Area:** pipeline (mega Stage 1.5 probe)
+**Status:** fixed
+**Keywords:** PROBE_MAX_PER_CAT, cap, truncation, interleave, round-robin, BBC, source diversity, per-source funnel, telemetry
+
+## Symptom
+
+Owner noticed today's News shipped from only 2 distinct sources (NPR ×2 +
+Al Jazeera) and asked "why isn't BBC included?" — BBC has been an enabled,
+live, priority-4 News source the whole time.
+
+## Root cause
+
+Reconstructed the 2026-07-08 run from `redesign_checkpoints`:
+
+| source (priority) | briefs | after forbidden | probe kept |
+|---|---|---|---|
+| PBS (1) | 4 | 3 | 3 |
+| NPR (2) | 4 | 4 | 4 |
+| Al Jazeera (3) | 4 | 4 | 3 |
+| **BBC (4)** | 4 | 4 | **0** |
+
+Stage 1.5 walked briefs in list order — and `phase_a_light` emits briefs
+grouped by source in cadence/priority order — keeping the first
+`PROBE_MAX_PER_CAT=10` that pass the word gate, then `break`. With 4
+sources × 4 briefs, the first three sources filled the cap and BBC's 4
+briefs were silently discarded before the curator ever saw them. On any
+day the higher-priority feeds are healthy, the last source gets ZERO
+probe slots — structural starvation, not editorial choice.
+
+(Also diagnosed in the same pass: PBS reached rank 3 and PASSED image
+verify, but was Stage-3 safety-rejected under the old any-dim≥3 rule —
+already fixed by the per-dimension thresholds, PR #37.)
+
+## Fix
+
+PR: fix/probe-cap-interleave.
+
+1. **`_interleave_by_source(briefs)`** (`pipeline/full_round.py`) —
+   round-robin briefs across sources (within-source order preserved)
+   before the probe, so the cap samples every source ~evenly (4 sources ×
+   cap 10 → 2-3 slots each).
+2. **`_partition_probe_results(...)`** — extracted the classify+cap loop
+   into a pure function that classifies EVERY brief (`in/kept/thin/long/
+   cap_cut` per source) instead of `break`-ing, so cap starvation is now
+   visible instead of silent.
+3. **Per-source funnel telemetry** — `phase_a_probe.per_source`,
+   `verify.per_source` (verified + reject reasons, source name now in the
+   FAIL log line), `stage3_safety.per_source` (shipped / safety_rejected +
+   reject reason logged with source name). Answers "which stage killed
+   source X" straight from `redesign_runs.telemetry`.
+
+## Invariant
+
+- The probe cap must never be applied to a source-grouped list — always
+  interleave first. A funnel stage that drops items silently (uncounted)
+  is a bug.
+
+## Pinning test
+
+`python -m pipeline.test_source_funnel` — esp.
+`test_interleave_plus_cap_keeps_every_source_represented` (reproduces the
+4×4-cap-10 BBC starvation) and
+`test_verify_picks_lazy_records_per_source_stats`.
+
+## Related
+
+- `docs/bugs/2026-07-08-news-safety-and-image-tuning.md` — PBS half of
+  the "only 2 sources" symptom (safety thresholds).
+- Follow-up (open): add more kid-oriented News sources; News has only 4
+  sources for a 5-pick curator, so one repeat source per day is
+  guaranteed by pigeonhole even with a fair cap.

--- a/docs/bugs/INDEX.md
+++ b/docs/bugs/INDEX.md
@@ -62,3 +62,4 @@ you must not break.
 - `docs/superpowers/specs/` — design docs for the feature the bug
   lives in. The spec tells you the *intended* shape; the bug record
   tells you *where reality diverged and what saved us*.
+| 2026-07-08 | [probe-cap-starves-low-priority-sources](2026-07-08-probe-cap-starves-low-priority-sources.md) | pipeline | BBC got 0 probe slots: Stage-1.5 cap ate briefs in source-priority order; fix = round-robin interleave + per-source funnel telemetry | fixed |

--- a/pipeline/full_round.py
+++ b/pipeline/full_round.py
@@ -719,14 +719,70 @@ def stamp_probe_outcomes(picked_by_cat: dict[str, list],
         log.info("probe outcomes stamped on %d unshipped source(s)", stamped)
 
 
+def _interleave_by_source(briefs: list[dict]) -> list[dict]:
+    """Round-robin briefs across sources (first-seen source order,
+    within-source order preserved). The Stage-1.5 probe cap walks briefs
+    in list order, and phase_a_light emits them grouped by source in
+    priority order — so with 4 News sources × 4 briefs and cap 10, the
+    priority-4 source (BBC) got ZERO probe slots on any day the earlier
+    feeds were healthy (found 2026-07-08 via checkpoint reconstruction).
+    Interleaving makes the cap sample every source fairly."""
+    by_src: dict[str, list[dict]] = {}
+    for b in briefs:
+        by_src.setdefault(b.get("_source_name") or "", []).append(b)
+    queues = list(by_src.values())
+    out: list[dict] = []
+    while queues:
+        queues = [q for q in queues if q]
+        for q in queues:
+            if q:
+                out.append(q.pop(0))
+    return out
+
+
+def _partition_probe_results(results: list[dict], min_words: int,
+                             max_words: int, cap: int,
+                             ) -> tuple[list[dict], dict[str, dict[str, int]]]:
+    """Classify probe results per source and apply the per-cat cap.
+    Returns (kept_briefs, tally) with tally[src] = {in, kept, thin, long,
+    cap_cut}. Unlike the old break-at-cap loop, every brief is classified,
+    so a source starved by the cap shows up as cap_cut in telemetry
+    instead of vanishing silently."""
+    kept: list[dict] = []
+    tally: dict[str, dict[str, int]] = {}
+    for r in results:
+        src = (r["brief"].get("_source_name") or "?")
+        t = tally.setdefault(
+            src, {"in": 0, "kept": 0, "thin": 0, "long": 0, "cap_cut": 0})
+        t["in"] += 1
+        wc = r["wc"]
+        if wc < min_words:
+            t["thin"] += 1
+        elif wc > max_words:
+            t["long"] += 1
+        elif len(kept) >= cap:
+            t["cap_cut"] += 1
+        else:
+            b = r["brief"]
+            b["_probe_art"] = r["art"]
+            b["word_count"] = wc
+            kept.append(b)
+            t["kept"] += 1
+    return kept, tally
+
+
 def verify_picks_lazy(ranked_by_cat: dict[str, list[dict]],
                        max_top: int = 4,
-                       min_body_words: int = 250) -> dict[str, list[dict]]:
+                       min_body_words: int = 250,
+                       stats: dict | None = None) -> dict[str, list[dict]]:
     """For each category's top-`max_top` ranked picks, fetch HTML body +
     og:image and verify. If a rank-1..4 pick fails, promote rank 5.
     Returns {cat: [story_dict_with_winner, ...]} where story_dict has
     `winner`, `source`, `winner_slot`, `_rank`. Includes the verified
     spares too (so Stage 3 can promote them on safety reject).
+
+    If `stats` (a dict) is passed, it is filled per category/source with
+    {"verified": n, "rejects": {reason: n}} for funnel telemetry.
     """
     from .news_rss_core import _fetch_and_enrich, verify_article_content
 
@@ -734,6 +790,12 @@ def verify_picks_lazy(ranked_by_cat: dict[str, list[dict]],
     for cat, ranked in ranked_by_cat.items():
         verified: list[dict] = []
         used: set[int] = set()
+
+        def _stat(r: dict) -> dict:
+            src = getattr(r.get("source"), "name", None) or "?"
+            cstats = stats.setdefault(cat, {}) if stats is not None else {}
+            return cstats.setdefault(src, {"verified": 0, "rejects": {}})
+
         # Walk in rank order; verify each. We aim to fill up to max_top
         # AND keep all ranks beyond as un-verified spares (verify lazily
         # later if Stage 3 needs them).
@@ -752,14 +814,23 @@ def verify_picks_lazy(ranked_by_cat: dict[str, list[dict]],
             art = dict(cached) if cached else _fetch_and_enrich(dict(brief))
             ok, reason = verify_article_content(art)
             if not ok:
-                log.info("  [%s] rank %s body-verify FAIL: %s",
-                         cat, r.get("rank"), reason)
+                log.info("  [%s] rank %s (%s) body-verify FAIL: %s",
+                         cat, r.get("rank"),
+                         getattr(r.get("source"), "name", "?"), reason)
+                if stats is not None:
+                    st = _stat(r)
+                    st["rejects"][reason] = st["rejects"].get(reason, 0) + 1
                 continue
             if (art.get("word_count") or 0) < min_body_words:
                 log.info("  [%s] rank %s too thin: %dw < %d",
                          cat, r.get("rank"), art.get("word_count", 0), min_body_words)
+                if stats is not None:
+                    st = _stat(r)
+                    st["rejects"]["too thin"] = st["rejects"].get("too thin", 0) + 1
                 continue
             used.add(cid)
+            if stats is not None:
+                _stat(r)["verified"] += 1
             verified.append({
                 "source": r["source"],
                 "winner": art,
@@ -1563,38 +1634,36 @@ def main_mega() -> None:
         kept_total = 0
         dropped_thin = 0
         dropped_long = 0
+        per_source: dict[str, dict] = {}
         for cat, briefs in briefs_by_cat.items():
             if not briefs:
                 out[cat] = []
                 continue
+            # Interleave across sources so the cap samples every source
+            # instead of eating the pool in priority order (BBC starvation,
+            # bug 2026-07-08).
+            briefs = _interleave_by_source(briefs)
             with ThreadPoolExecutor(max_workers=PROBE_WORKERS) as ex:
                 results = list(ex.map(_probe_one, briefs))
-            kept: list[dict] = []
-            for r in results:
-                wc = r["wc"]
-                if wc < PROBE_MIN_WORDS:
-                    dropped_thin += 1
-                    continue
-                if wc > PROBE_MAX_WORDS:
-                    dropped_long += 1
-                    continue
-                b = r["brief"]
-                b["_probe_art"] = r["art"]
-                b["word_count"] = wc
-                kept.append(b)
-                if len(kept) >= PROBE_MAX_PER_CAT:
-                    break
+            kept, tally = _partition_probe_results(
+                results, PROBE_MIN_WORDS, PROBE_MAX_WORDS, PROBE_MAX_PER_CAT)
             out[cat] = kept
+            per_source[cat] = tally
             kept_total += len(kept)
-            log.info("  [%s] probe: %d kept / %d input (dropped %d thin, %d long)",
+            dropped_thin += sum(t["thin"] for t in tally.values())
+            dropped_long += sum(t["long"] for t in tally.values())
+            log.info("  [%s] probe: %d kept / %d input · %s",
                      cat, len(kept), len(briefs),
-                     sum(1 for r in results if r["wc"] < PROBE_MIN_WORDS),
-                     sum(1 for r in results if r["wc"] > PROBE_MAX_WORDS))
+                     ", ".join(
+                         f"{s}:{t['kept']}/{t['in']}"
+                         + (f" (cap_cut {t['cap_cut']})" if t["cap_cut"] else "")
+                         for s, t in tally.items()))
         _set_phase("phase_a_probe", t0,
                    counts={c: len(b) for c, b in out.items()},
                    dropped_thin=dropped_thin,
                    dropped_long=dropped_long,
-                   kept=kept_total)
+                   kept=kept_total,
+                   per_source=per_source)
         return out
     briefs_by_cat = _load_or_run("phase_a_probe", _stage1_5_runner)
 
@@ -1612,10 +1681,11 @@ def main_mega() -> None:
     def _verify_runner():
         t0 = time.monotonic()
         log.info("=== MEGA verify body + og:image on rank 1-4 ===")
-        out = verify_picks_lazy(ranked_by_cat, max_top=4)
+        vstats: dict = {}
+        out = verify_picks_lazy(ranked_by_cat, max_top=4, stats=vstats)
         verified_counts = {c: sum(1 for s in v if not s.get("_unverified_spare"))
                            for c, v in out.items()}
-        _set_phase("verify", t0, verified=verified_counts)
+        _set_phase("verify", t0, verified=verified_counts, per_source=vstats)
         for cat, ws in out.items():
             verified = [s for s in ws if not s.get("_unverified_spare")]
             log.info("  [%s] %d verified + %d spare ranks",
@@ -1659,13 +1729,24 @@ def main_mega() -> None:
     # ---- Stage 3: Python safety filter on rewritten bodies ----
     def _safety_runner():
         t0 = time.monotonic()
-        log.info("=== MEGA Stage 3 — Python safety filter (any_dim ≥ 3 = REJECT) ===")
+        log.info("=== MEGA Stage 3 — Python safety filter "
+                 "(strict dims ≥3 / news dims ≥4 = REJECT) ===")
         final_stories: dict[str, list[dict]] = {}
         final_variants: dict[str, dict[int, dict]] = {}
+        s3_per_source: dict[str, dict] = {}
         for cat, bundle in rewrites_by_cat.items():
             winners = bundle.get("_winners") or []
             rewrite_res = {"articles": bundle.get("articles") or []}
             kept, rejected = filter_safe_rewrites(rewrite_res)
+            cs = s3_per_source.setdefault(cat, {})
+            for a in rejected:
+                sid = a.get("source_id")
+                w = winners[sid] if isinstance(sid, int) and 0 <= sid < len(winners) else None
+                name = w["source"].name if w and w.get("source") else "?"
+                e = cs.setdefault(name, {"shipped": 0, "safety_rejected": 0})
+                e["safety_rejected"] += 1
+                reason = ((a.get("_safety_eval") or {}).get("reason") or "")[:120]
+                log.info("  [%s] Stage-3 REJECT %s: %s", cat, name, reason)
             kept_by_sid: dict[int, dict] = {a["source_id"]: a for a in kept
                                              if isinstance(a.get("source_id"), int)}
             survived_winners: list[dict] = []
@@ -1698,6 +1779,9 @@ def main_mega() -> None:
                     break
             final_stories[cat] = survived_winners[:3]
             final_variants[cat] = {i: art for i, art in enumerate(survived_articles[:3])}
+            for w in final_stories[cat]:
+                name = w["source"].name if w.get("source") else "?"
+                cs.setdefault(name, {"shipped": 0, "safety_rejected": 0})["shipped"] += 1
             if promotions:
                 telemetry["warnings"].append(
                     f"{cat}: Stage 3 promoted {promotions} spare(s) to fill the slot")
@@ -1706,7 +1790,7 @@ def main_mega() -> None:
                     f"{cat}: only {len(survived_winners)} stories shipped after Stage 3")
             log.info("  [%s] final: %d stories (%d rejected, %d promoted)",
                      cat, len(survived_winners), len(rejected), promotions)
-        _set_phase("stage3_safety", t0)
+        _set_phase("stage3_safety", t0, per_source=s3_per_source)
         # Bundle both products into a single checkpoint payload.
         return {"final_stories_by_cat": final_stories, "final_variants_by_cat": final_variants}
 

--- a/pipeline/test_source_funnel.py
+++ b/pipeline/test_source_funnel.py
@@ -1,0 +1,115 @@
+"""Tests for per-source funnel fairness + telemetry (2026-07-08).
+
+Root cause found via checkpoint reconstruction of the 2026-07-08 run:
+the Stage-1.5 probe cap (PROBE_MAX_PER_CAT=10) consumed briefs in source-
+priority order, so with 4 News sources × 4 briefs the first three sources
+filled the cap and BBC (priority 4) never reached the curator — on any day
+the earlier feeds are healthy. Fix: round-robin interleave briefs across
+sources before the cap, and record a per-source tally at each funnel stage
+(probe / verify / stage-3) so the next starvation is visible in telemetry.
+
+Run: python -m pipeline.test_source_funnel   (also works under pytest)
+"""
+from __future__ import annotations
+
+from pipeline import full_round as fr
+
+
+def _b(src: str, title: str) -> dict:
+    return {"title": title, "_source_name": src}
+
+
+# ── 1. round-robin interleave ──
+
+def test_interleave_round_robins_sources():
+    briefs = ([_b("A", f"a{i}") for i in range(4)]
+              + [_b("B", f"b{i}") for i in range(4)]
+              + [_b("C", f"c{i}") for i in range(2)])
+    out = fr._interleave_by_source(briefs)
+    # First pass touches every source once, in first-seen order.
+    assert [x["_source_name"] for x in out[:3]] == ["A", "B", "C"]
+    # Within-source order preserved.
+    assert [x["title"] for x in out if x["_source_name"] == "A"] == \
+        ["a0", "a1", "a2", "a3"]
+    # Nothing lost, nothing duplicated.
+    assert sorted(x["title"] for x in out) == sorted(x["title"] for x in briefs)
+
+
+def test_interleave_handles_empty_and_single_source():
+    assert fr._interleave_by_source([]) == []
+    solo = [_b("A", "a0"), _b("A", "a1")]
+    assert fr._interleave_by_source(solo) == solo
+
+
+# ── 2. probe partition: classify per source, cap without silent starvation ──
+
+def _r(src: str, i: int, wc: int) -> dict:
+    return {"brief": _b(src, f"{src}{i}"), "art": {"word_count": wc}, "wc": wc}
+
+
+def test_partition_classifies_thin_long_and_cap():
+    results = [_r("A", 0, 500), _r("B", 0, 200),   # B0 thin
+               _r("A", 1, 2000), _r("B", 1, 500),  # A1 long
+               _r("A", 2, 500), _r("B", 2, 500)]   # B2 over cap
+    kept, tally = fr._partition_probe_results(results, 350, 1200, cap=3)
+    assert [b["title"] for b in kept] == ["A0", "B1", "A2"]
+    # Kept briefs carry the cached article + word_count (probe contract).
+    assert kept[0]["_probe_art"] == {"word_count": 500}
+    assert kept[0]["word_count"] == 500
+    assert tally["A"] == {"in": 3, "kept": 2, "thin": 0, "long": 1, "cap_cut": 0}
+    assert tally["B"] == {"in": 3, "kept": 1, "thin": 1, "long": 0, "cap_cut": 1}
+
+
+def test_interleave_plus_cap_keeps_every_source_represented():
+    # The 2026-07-08 regression: 4 sources × 4 briefs, all pass the word
+    # gate, cap 10 — in priority order the 4th source got zero slots.
+    ordered = []
+    for src in ("PBS", "NPR", "AJ", "BBC"):
+        ordered += [_b(src, f"{src}-{i}") for i in range(4)]
+    inter = fr._interleave_by_source(ordered)
+    results = [{"brief": b, "art": {"word_count": 500}, "wc": 500} for b in inter]
+    kept, tally = fr._partition_probe_results(results, 350, 1200, cap=10)
+    kept_srcs = {b["_source_name"] for b in kept}
+    assert kept_srcs == {"PBS", "NPR", "AJ", "BBC"}, f"starved: {kept_srcs}"
+    # Fair split: every source lands 2-3 of the 10 slots.
+    for src in ("PBS", "NPR", "AJ", "BBC"):
+        assert 2 <= tally[src]["kept"] <= 3, tally
+
+
+# ── 3. verify_picks_lazy per-source stats ──
+
+class _Src:
+    def __init__(self, name): self.name = name
+
+
+def test_verify_picks_lazy_records_per_source_stats():
+    npr = _Src("NPR World")
+    good = {"word_count": 400, "og_image": "https://x/real.jpg", "title": "good"}
+    bad = {"word_count": 400, "og_image": None, "title": "bad"}
+    ranked = {"News": [
+        {"id": 1, "rank": 1, "source": npr,
+         "brief": {"_probe_art": bad, "_source_name": "NPR World"}},
+        {"id": 2, "rank": 2, "source": npr,
+         "brief": {"_probe_art": good, "_source_name": "NPR World"}},
+    ]}
+    stats: dict = {}
+    out = fr.verify_picks_lazy(ranked, max_top=4, stats=stats)
+    verified = [s for s in out["News"] if not s.get("_unverified_spare")]
+    assert len(verified) == 1
+    assert verified[0]["winner"]["title"] == "good"
+    s = stats["News"]["NPR World"]
+    assert s["verified"] == 1
+    assert s["rejects"] == {"no og:image": 1}
+
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"  PASS {fn.__name__}")
+    print(f"OK — {len(fns)} tests passed")
+
+
+if __name__ == "__main__":
+    _run_all()


### PR DESCRIPTION
Today News shipped from only 2 sources. Checkpoint reconstruction showed BBC got 0 probe slots: the Stage-1.5 cap (10) consumed briefs in source-priority order, so sources ranked 1-3 filled it and BBC never reached the curator. (PBS separately passed image verify but was rejected by the old any-dim≥3 safety rule — already fixed in #37.)

- `_interleave_by_source`: round-robin briefs across sources before the cap → 4 sources get ~2-3 slots each
- `_partition_probe_results`: classify every brief per source (in/kept/thin/long/cap_cut) — no more silent truncation
- per-source funnel telemetry at probe / verify / stage-3 (+ source names & reject reasons in logs), readable from `redesign_runs.telemetry`
- tests: `pipeline/test_source_funnel.py` (5) reproduce the 4×4-cap-10 starvation; all existing suites green

**Backend-only — no auto-deploy.** Takes effect at the next daily run; expect BBC briefs in the curator pool and 3-source News diversity.

🤖 Generated with [Claude Code](https://claude.com/claude-code)