### PR TITLE
feat(pipeline): partial-category run with safe bundle merge

### DIFF
--- a/.github/workflows/daily-pipeline.yml
+++ b/.github/workflows/daily-pipeline.yml
@@ -17,6 +17,10 @@ on:
         description: "Internal — set by pipeline-watchdog to prevent retry-of-retry loop"
         type: boolean
         default: false
+      categories:
+        description: "Partial run — comma-separated categories (e.g. News). Other categories keep today's live content (merged from latest.zip). Empty = all."
+        type: string
+        default: ''
   schedule:
     # Hardcoded admin-configured fire time. Synced FROM
     # `redesign_cron_config` table by the quality-digest workflow at
@@ -156,6 +160,9 @@ jobs:
           # Optional checkpoint resume — only honored on workflow_dispatch
           # (scheduled runs always start fresh).
           RESUME_FROM: ${{ inputs.resume_from || '' }}
+          # Optional partial run (workflow_dispatch only): regenerate just
+          # these categories; the rest merge in from the live latest.zip.
+          PIPELINE_CATEGORIES: ${{ inputs.categories || '' }}
         run: python -m pipeline.full_round
 
       - name: Refresh search index

--- a/pipeline/full_round.py
+++ b/pipeline/full_round.py
@@ -1003,6 +1003,60 @@ def rewrite_for_category(stories: list[dict],
 
 
 # -------------------------------------------------------------------
+# 3.5) Partial-run helpers (PIPELINE_CATEGORIES=News → run one category)
+# -------------------------------------------------------------------
+
+def _filter_categories(available: list[str], requested: str) -> list[str]:
+    """Resolve a comma-separated PIPELINE_CATEGORIES value against the
+    DB-active category names (case-insensitive). Unknown names are a
+    hard error — a typo must never silently run the full pipeline."""
+    by_lower = {c.lower(): c for c in available}
+    out: list[str] = []
+    unknown: list[str] = []
+    for raw in requested.split(","):
+        name = raw.strip()
+        if not name:
+            continue
+        canon = by_lower.get(name.lower())
+        if canon is None:
+            unknown.append(name)
+        elif canon not in out:
+            out.append(canon)
+    if unknown:
+        raise SystemExit(
+            f"PIPELINE_CATEGORIES unknown: {unknown} (active: {available})")
+    if not out:
+        raise SystemExit("PIPELINE_CATEGORIES is set but empty")
+    return out
+
+
+def _archive_replaced_stories(cats: list[str], date_str: str) -> None:
+    """Partial-run hygiene: mark today's existing rows for the re-run
+    categories archived=true and drop their search-index rows, so the
+    replaced stories don't double-count in digests or linger in search.
+    Non-fatal on error — the re-run content itself is unaffected."""
+    from .supabase_io import client
+    try:
+        sb = client()
+        r = (sb.table("redesign_stories")
+               .update({"archived": True})
+               .eq("published_date", date_str)
+               .in_("category", cats)
+               .execute())
+        rows = r.data or []
+        sids = [row.get("payload_story_id") for row in rows
+                if row.get("payload_story_id")]
+        log.info("partial: archived %d replaced %s stories",
+                 len(rows), "/".join(cats))
+        if sids:
+            sb.table("redesign_search_index").delete() \
+              .in_("story_id", sids).execute()
+            log.info("partial: dropped %d search-index story ids", len(sids))
+    except Exception as e:  # noqa: BLE001
+        log.warning("partial: archive/search cleanup failed (non-fatal): %s", e)
+
+
+# -------------------------------------------------------------------
 # 4) Emit v1-shape payload files (what the existing v2 UI reads)
 # -------------------------------------------------------------------
 
@@ -1053,7 +1107,10 @@ def emit_v1_shape(stories_by_cat: dict[str, list[dict]],
 
     mined_at = datetime.now(timezone.utc).isoformat(timespec="seconds")
 
-    for category in ("News", "Science", "Fun"):
+    # Only the categories actually passed in — a partial run must not
+    # emit EMPTY listings for absent categories (the pack merge would
+    # ship them over good live content).
+    for category in stories_by_cat:
         stories = stories_by_cat.get(category, [])
         variants = variants_by_cat.get(category, {})
         details = details_by_cat.get(category, {})
@@ -1180,6 +1237,11 @@ def persist_to_supabase(stories_by_cat, variants_by_cat, today: str, run_id: str
                 "primary_image_url": s.get("_image_storage_url") or art.get("og_image"),
                 "primary_image_local": s.get("_image_local"),
                 "primary_image_credit": src_host,
+                # Explicit: a freshly-shipped story is never archived. The
+                # (date,category,slot) upsert overwrites a partial-run's
+                # superseded row, which _archive_replaced_stories just
+                # flagged — without this the flag would stick to the NEW row.
+                "archived": False,
                 "payload_path": f"payloads/articles_{category.lower()}_easy.json",
                 "payload_story_id": story_id,
             }
@@ -1537,6 +1599,23 @@ def main_mega() -> None:
     cat_names = [c["name"] for c in categories]
     log.info("=== MEGA active categories from DB: %s ===", cat_names)
 
+    # ---- Partial run (PIPELINE_CATEGORIES=News): one category only ----
+    # Checkpoints are disabled (a partial save would clobber the day's
+    # full-run trail) and pack_and_upload runs in merge mode — the other
+    # categories' content is spliced in from the live latest.zip, so the
+    # site never loses a category.
+    requested_cats = (os.environ.get("PIPELINE_CATEGORIES") or "").strip()
+    partial_cats: list[str] | None = None
+    if requested_cats:
+        if (os.environ.get("RESUME_FROM") or "").strip():
+            raise SystemExit(
+                "PIPELINE_CATEGORIES cannot be combined with RESUME_FROM")
+        cat_names = _filter_categories(cat_names, requested_cats)
+        partial_cats = cat_names
+        telemetry["partial_categories"] = cat_names
+        log.info("=== PARTIAL RUN — categories: %s (checkpoints off, "
+                 "pack merges the rest from live bundle) ===", cat_names)
+
     # Build a {(name, rss_url): NewsSource} map across every category's
     # primary + backup feed list. Checkpoint hydration uses this to
     # resurrect Source dataclass instances from JSON refs.
@@ -1554,7 +1633,11 @@ def main_mega() -> None:
 
     def _load_or_run(stage: str, runner):
         """If we're resuming past `stage`, load the stage's checkpoint.
-        Otherwise run `runner()`, save the result, return it."""
+        Otherwise run `runner()`, save the result, return it.
+        Partial runs never checkpoint — a single-category save would
+        clobber the day's full-run trail (used for funnel diagnosis)."""
+        if partial_cats is not None:
+            return runner()
         if resume_target and ckpt.STAGES.index(stage) < ckpt.STAGES.index(resume_target):
             log.info("  [%s] resume: loading checkpoint", stage)
             return ckpt.load(stage, source_lookup, run_date=today)
@@ -1866,12 +1949,17 @@ def main_mega() -> None:
         if resume_target and ckpt.STAGES.index("persist") < ckpt.STAGES.index(resume_target):
             log.info("=== resume: skipping persist (already done) ===")
         else:
+            if partial_cats:
+                # Replacing today's content for these categories — mark the
+                # superseded rows + purge their search-index entries first.
+                _archive_replaced_stories(partial_cats, today)
             count = persist_to_supabase(final_stories_by_cat,
                                          final_variants_by_cat, today, run_id)
             update_run(run_id, {"status": "persisted",
                                  "notes": f"stories persisted: {count}",
                                  "telemetry": telemetry})
-            ckpt.save("persist", {"stories_persisted": count}, run_date=today)
+            if partial_cats is None:
+                ckpt.save("persist", {"stories_persisted": count}, run_date=today)
     _set_phase("persist", t, stories_persisted=count)
 
     # Close the pickup loop: record outcomes for picked-but-unshipped
@@ -1891,6 +1979,10 @@ def main_mega() -> None:
     upload_err: str | None = None
     try:
         from .pack_and_upload import main as _pack_upload
+        if partial_cats:
+            # Merge mode: pack splices the other categories' content from
+            # the live latest.zip; validation still gates the publish.
+            os.environ["PACK_MERGE_CATEGORIES"] = ",".join(partial_cats)
         _pack_upload()
         upload_ok = True
     except SystemExit as e:

--- a/pipeline/pack_and_upload.py
+++ b/pipeline/pack_and_upload.py
@@ -17,6 +17,7 @@ import json
 import logging
 import os
 import re
+import shutil
 import sys
 import zipfile
 from datetime import datetime, timezone
@@ -96,18 +97,21 @@ DETAIL_MIN = [
 ]
 
 
-def validate_bundle(today: str) -> None:
+def validate_bundle(today: str, content_root: Path | None = None) -> None:
     """Fail (SystemExit 1) if today's bundle is incomplete. Check:
       · 9 listing files (3 cats × easy/middle/cn), each with exactly 3 articles
       · 18 detail payloads (9 stories × easy/middle), each with non-empty
         keywords/questions/background_read/Article_Structure
       · 9 article images on disk (one per story id)
+    `content_root` overrides where content is read from (merge mode);
+    default is the local website dir.
     """
+    root = content_root or WEB
     errs: list[str] = []
 
     # Listing files — 2 or 3 per cat/lvl acceptable (ideal=3; 2 after
     # cross-source dup drops when all backups are exhausted). <2 is fatal.
-    payloads = WEB / "payloads"
+    payloads = root / "payloads"
     short_cats: set[str] = set()  # cats that shipped <3
     for cat in CATS:
         for lvl in ("easy", "middle", "cn"):
@@ -133,7 +137,7 @@ def validate_bundle(today: str) -> None:
     # Detail payloads (easy + middle only; cn has no detail page) — iterate
     # actual story IDs from the middle listing so 2-article cats validate
     # cleanly.
-    details = WEB / "article_payloads"
+    details = root / "article_payloads"
     all_story_ids: list[str] = []
     for cat in CATS:
         p = payloads / f"articles_{cat}_middle.json"
@@ -167,7 +171,7 @@ def validate_bundle(today: str) -> None:
                 errs.append(f"{story_id}/{lvl}: parse error {e}")
 
     # Per-story images (same image used across easy/middle for a story)
-    images_dir = WEB / "article_images"
+    images_dir = root / "article_images"
     needed_images: set[str] = set()
     for cat in CATS:
         # Pull image_urls from today's listings — whichever level works
@@ -282,12 +286,14 @@ def build_zip(content_root: Path | None = None) -> bytes:
     return buf.getvalue()
 
 
-def build_manifest(today: str, body: bytes) -> dict:
+def build_manifest(today: str, body: bytes,
+                   content_root: Path | None = None) -> dict:
     """Summarize what this zip contains — version + content hash + story IDs.
     Consumers can compare manifest sha256 without downloading the zip."""
+    root = content_root or WEB
     stories: list[dict] = []
     for cat in CATS:
-        p = WEB / "payloads" / f"articles_{cat}_middle.json"
+        p = root / "payloads" / f"articles_{cat}_middle.json"
         if not p.is_file():
             continue
         try:
@@ -311,6 +317,80 @@ def build_manifest(today: str, body: bytes) -> dict:
         "story_count": len(stories),
         "stories": stories,
     }
+
+
+def _overlay_fresh_categories(old_root: Path, fresh_root: Path,
+                              cats: set[str]) -> None:
+    """Splice freshly-generated categories into an extracted copy of the
+    live bundle (partial-run merge). For each cat in `cats` (lowercase,
+    e.g. 'news'): replace its 3 listing files, remove artifacts of the
+    replaced story ids (detail dirs / images / PDFs), copy the fresh
+    ones in. Everything else in old_root is untouched. A missing fresh
+    listing aborts — never publish a bundle with a category-shaped hole."""
+
+    def _ids_imgs(p: Path) -> tuple[set[str], set[str]]:
+        ids: set[str] = set()
+        imgs: set[str] = set()
+        try:
+            for a in (json.loads(p.read_text()).get("articles") or []):
+                if a.get("id"):
+                    ids.add(str(a["id"]))
+                if a.get("image_url"):
+                    imgs.add(Path(a["image_url"]).name)
+        except Exception as e:  # noqa: BLE001
+            raise SystemExit(f"merge: unreadable listing {p}: {e}")
+        return ids, imgs
+
+    for cat in sorted(cats):
+        old_ids: set[str] = set()
+        old_imgs: set[str] = set()
+        new_ids: set[str] = set()
+        new_imgs: set[str] = set()
+        for lvl in ("easy", "middle", "cn"):
+            rel = f"payloads/articles_{cat}_{lvl}.json"
+            fresh_p = fresh_root / rel
+            if not fresh_p.is_file():
+                raise SystemExit(f"merge: fresh listing missing: {rel}")
+            old_p = old_root / rel
+            if old_p.is_file():
+                ids, imgs = _ids_imgs(old_p)
+                old_ids |= ids
+                old_imgs |= imgs
+            ids, imgs = _ids_imgs(fresh_p)
+            new_ids |= ids
+            new_imgs |= imgs
+            old_p.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(fresh_p, old_p)
+        # Drop artifacts of replaced stories that are NOT re-shipped
+        # (same-slot ids overwrite in place below).
+        for sid in old_ids - new_ids:
+            shutil.rmtree(old_root / "article_payloads" / f"payload_{sid}",
+                          ignore_errors=True)
+            for pdf in (old_root / "article_pdfs").glob(f"{sid}-*.pdf"):
+                pdf.unlink()
+        for img in old_imgs - new_imgs:
+            old_img = old_root / "article_images" / img
+            if old_img.is_file():
+                old_img.unlink()
+        # Copy the fresh artifacts in.
+        for sid in new_ids:
+            src = fresh_root / "article_payloads" / f"payload_{sid}"
+            if src.is_dir():
+                dst = old_root / "article_payloads" / f"payload_{sid}"
+                shutil.rmtree(dst, ignore_errors=True)
+                shutil.copytree(src, dst)
+            for pdf in (fresh_root / "article_pdfs").glob(f"{sid}-*.pdf"):
+                dst_dir = old_root / "article_pdfs"
+                dst_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(pdf, dst_dir / pdf.name)
+        for img in new_imgs:
+            src = fresh_root / "article_images" / img
+            if src.is_file():
+                dst_dir = old_root / "article_images"
+                dst_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst_dir / img)
+        log.info("merge: [%s] %d fresh stories in, %d replaced out",
+                 cat, len(new_ids), len(old_ids - new_ids))
 
 
 DATED_ZIP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})\.zip$")
@@ -523,6 +603,56 @@ def main() -> None:
     # are content-driven, not shell-driven).
     republish = os.environ.get("PACK_REPUBLISH_ONLY") == "1"
     sb = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_SERVICE_KEY"])
+
+    # Merge mode (partial category run): fresh content for SOME categories
+    # is on local disk; everything else comes from the live latest.zip.
+    # Full validation still gates the publish — a bad merge refuses to
+    # upload and the site keeps its current bundle.
+    merge_env = (os.environ.get("PACK_MERGE_CATEGORIES") or "").strip()
+    merge_cats = {c.strip().lower() for c in merge_env.split(",") if c.strip()}
+    if merge_cats:
+        if republish:
+            raise SystemExit("PACK_MERGE_CATEGORIES and PACK_REPUBLISH_ONLY "
+                             "are mutually exclusive")
+        unknown = merge_cats - set(CATS)
+        if unknown:
+            raise SystemExit(f"PACK_MERGE_CATEGORIES unknown: {sorted(unknown)}")
+        import tempfile
+        merge_root = Path(tempfile.mkdtemp(prefix="pack_merge_"))
+        try:
+            blob = sb.storage.from_(BUCKET).download("latest.zip")
+        except Exception as e:  # noqa: BLE001
+            # No fallback: local disk only has the fresh categories, so
+            # packing local-only would ship a bundle missing the rest.
+            raise SystemExit(f"merge mode needs the live latest.zip: {e}")
+        with zipfile.ZipFile(BytesIO(blob)) as zf:
+            for info in zf.infolist():
+                top = info.filename.split("/", 1)[0]
+                if top in CONTENT_DIRS:
+                    zf.extract(info, merge_root)
+        _overlay_fresh_categories(merge_root, WEB, merge_cats)
+        validate_bundle(today, content_root=merge_root)
+        body = build_zip(content_root=merge_root)
+        manifest = build_manifest(today, body, content_root=merge_root)
+        manifest_bytes = json.dumps(manifest, ensure_ascii=False, indent=2).encode()
+        check_not_overwriting_newer(sb)
+        for key in (f"{today}.zip", "latest.zip"):
+            sb.storage.from_(BUCKET).upload(
+                path=key, file=body,
+                file_options={"content-type": "application/zip", "upsert": "true"})
+            log.info("uploaded %s", key)
+        for key in (f"{today}-manifest.json", "latest-manifest.json"):
+            sb.storage.from_(BUCKET).upload(
+                path=key, file=manifest_bytes,
+                file_options={"content-type": "application/json", "upsert": "true"})
+            log.info("uploaded %s", key)
+        try:
+            upload_dated_flat_files(sb, today, bundle=body)
+        except Exception as e:  # noqa: BLE001
+            log.warning("dated-flat upload failed (non-fatal): %s", e)
+        log.info("merge publish done: %s replaced · stories=%d",
+                 sorted(merge_cats), manifest["story_count"])
+        return
 
     if republish:
         # Pull current latest.zip and extract CONTENT_DIRS to a temp dir

--- a/pipeline/test_partial_run.py
+++ b/pipeline/test_partial_run.py
@@ -1,0 +1,132 @@
+"""Tests for the partial-run (single-category) feature (2026-07-08).
+
+Owner ask: "单独直接跑 news" — re-run ONE category (e.g. News) without
+touching the other categories' live content. Design:
+  · PIPELINE_CATEGORIES=News scopes the mega funnel to that category
+    (checkpoints disabled so the day's full-run trail isn't clobbered).
+  · emit_v1_shape only writes listings for categories it was given —
+    previously it emitted EMPTY listings for absent categories, which a
+    naive merge would have shipped over good live content.
+  · pack_and_upload merge mode (PACK_MERGE_CATEGORIES=news): pull the
+    live latest.zip, splice ONLY the fresh categories' files in, then run
+    the normal ≥2-per-cat validation — a bad merge refuses to publish and
+    the site keeps its current content.
+
+Run: python -m pipeline.test_partial_run   (also works under pytest)
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from pipeline import full_round as fr
+from pipeline import pack_and_upload as pk
+
+
+# ── 1. category filter ──
+
+def test_filter_categories_case_insensitive_subset():
+    avail = ["News", "Science", "Fun"]
+    assert fr._filter_categories(avail, "news") == ["News"]
+    assert fr._filter_categories(avail, "News,fun") == ["News", "Fun"]
+
+
+def test_filter_categories_unknown_raises():
+    try:
+        fr._filter_categories(["News", "Science", "Fun"], "Sports")
+    except SystemExit as e:
+        assert "Sports" in str(e)
+    else:
+        raise AssertionError("unknown category must SystemExit")
+
+
+# ── 2. emit only writes categories it was given ──
+
+def test_emit_skips_absent_categories():
+    with tempfile.TemporaryDirectory() as td:
+        web = Path(td)
+        fr.emit_v1_shape({"News": []}, {"News": {}}, {"News": {}},
+                         "2026-07-08", web)
+        assert (web / "payloads" / "articles_news_easy.json").is_file()
+        # The old hardcoded loop wrote EMPTY science/fun listings here —
+        # which the pack merge would then ship over good live content.
+        assert not (web / "payloads" / "articles_science_easy.json").exists()
+        assert not (web / "payloads" / "articles_fun_middle.json").exists()
+
+
+# ── 3. bundle merge: splice fresh category into extracted live bundle ──
+
+def _listing(ids_imgs: list[tuple[str, str]]) -> str:
+    return json.dumps({"articles": [
+        {"id": i, "title": f"t-{i}", "summary": "s",
+         "image_url": f"article_images/{img}"} for i, img in ids_imgs]})
+
+
+def _seed(root: Path, cat: str, ids_imgs: list[tuple[str, str]]) -> None:
+    (root / "payloads").mkdir(parents=True, exist_ok=True)
+    for lvl in ("easy", "middle", "cn"):
+        (root / "payloads" / f"articles_{cat}_{lvl}.json").write_text(
+            _listing(ids_imgs))
+    for sid, img in ids_imgs:
+        d = root / "article_payloads" / f"payload_{sid}"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "middle.json").write_text("{}")
+        (root / "article_images").mkdir(parents=True, exist_ok=True)
+        (root / "article_images" / img).write_bytes(b"x")
+        (root / "article_pdfs").mkdir(parents=True, exist_ok=True)
+        (root / "article_pdfs" / f"{sid}-middle.pdf").write_bytes(b"p")
+
+
+def test_overlay_replaces_only_named_category():
+    with tempfile.TemporaryDirectory() as t1, tempfile.TemporaryDirectory() as t2:
+        old, fresh = Path(t1), Path(t2)
+        _seed(old, "news", [("n_old1", "old1.webp"), ("n_old2", "old2.webp")])
+        _seed(old, "science", [("s1", "s1.webp")])
+        _seed(fresh, "news", [("n_new1", "new1.webp")])
+
+        pk._overlay_fresh_categories(old, fresh, {"news"})
+
+        # News listing replaced with the fresh one.
+        doc = json.loads((old / "payloads" / "articles_news_middle.json").read_text())
+        assert [a["id"] for a in doc["articles"]] == ["n_new1"]
+        # Old News artifacts removed …
+        assert not (old / "article_payloads" / "payload_n_old1").exists()
+        assert not (old / "article_images" / "old2.webp").exists()
+        assert not (old / "article_pdfs" / "n_old1-middle.pdf").exists()
+        # … fresh News artifacts spliced in …
+        assert (old / "article_payloads" / "payload_n_new1" / "middle.json").is_file()
+        assert (old / "article_images" / "new1.webp").is_file()
+        assert (old / "article_pdfs" / "n_new1-middle.pdf").is_file()
+        # … and Science untouched.
+        assert (old / "article_payloads" / "payload_s1").is_dir()
+        assert (old / "article_images" / "s1.webp").is_file()
+        doc_s = json.loads((old / "payloads" / "articles_science_easy.json").read_text())
+        assert [a["id"] for a in doc_s["articles"]] == ["s1"]
+
+
+def test_overlay_missing_fresh_listing_aborts():
+    with tempfile.TemporaryDirectory() as t1, tempfile.TemporaryDirectory() as t2:
+        old, fresh = Path(t1), Path(t2)
+        _seed(old, "news", [("n1", "n1.webp")])
+        # fresh root has NO news listings → must refuse (never publish a
+        # bundle with a hole where a category used to be).
+        try:
+            pk._overlay_fresh_categories(old, fresh, {"news"})
+        except SystemExit:
+            pass
+        else:
+            raise AssertionError("missing fresh listing must SystemExit")
+
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"  PASS {fn.__name__}")
+    print(f"OK — {len(fns)} tests passed")
+
+
+if __name__ == "__main__":
+    _run_all()


### PR DESCRIPTION
Owner ask: 单独直接跑 News. Adds a `categories` input to the daily-pipeline workflow (e.g. `News`): the mega funnel runs only for those categories, and pack_and_upload splices the OTHER categories' content from the live latest.zip before the normal ≥2-per-cat validation. Validation failure = no publish = site keeps its current bundle, so a partial run can never leave a category-shaped hole.

Details: checkpoints disabled on partial runs (preserves the day's full-run diagnostic trail); emit no longer writes empty listings for absent categories; story rows upsert in place on (date, category, slot) with `archived:false` stamped; superseded rows flagged + search-index entries dropped; dated flat files re-uploaded from the merged zip.

Tests: `pipeline/test_partial_run.py` (5) — category filter, emit scoping, overlay splice/cleanup, missing-listing abort. All existing suites green.

**Backend-only — no auto-deploy.** First use: re-run News today to replace the two generic NPR images.

🤖 Generated with [Claude Code](https://claude.com/claude-code)