### PR TITLE
fix(pipeline): deep backfill + per-category degraded publish (no more all-or-nothing)

### DIFF
--- a/docs/bugs/2026-07-08-thin-category-sinks-whole-publish.md
+++ b/docs/bugs/2026-07-08-thin-category-sinks-whole-publish.md
@@ -1,0 +1,58 @@
+# 2026-07-08 — thin category sinks whole publish; backfill pool too shallow
+
+**Severity:** high
+**Area:** pipeline (Stage-3 backfill + pack gating)
+**Status:** fixed
+**Keywords:** backfill, spare pool, probe briefs, degraded publish, merge mode, SystemExit, deploy_failed, one-category failure
+
+## Symptom
+
+2026-07-08 06:06 run: News survived Stage 3 with only 1 story → pack
+validation SystemExit → **nothing** published (Science/Fun were perfectly
+fine) → run marked deploy_failed → full re-run needed (double LLM cost).
+Owner: "有一些文章没有,就导致整个 reject,我觉得这不好。4 个源,
+不管怎么样也找得到 3 篇合格的文章…不应该 crash 整个 pipeline 重新跑。"
+
+## Root cause (two stacked problems)
+
+1. **Backfill pool too shallow.** Probe keeps 10 briefs/cat, but the
+   curator ranks only 5, and Stage-3 spare promotion could only draw from
+   the curator's leftover ranks (usually 1 spare). The other ~5 probed
+   briefs — bodies already fetched — were silently discarded. After
+   verify/safety attrition there was often nothing left to promote.
+2. **All-or-nothing pack.** `validate_bundle` (≥2/cat) aborted the WHOLE
+   upload on one thin category, discarding the other categories' fresh
+   content and blocking any publish.
+
+## Fix
+
+PR: fix/deep-backfill-degraded-publish.
+
+1. **Deep backfill** — `_unpicked_probe_spares` (full_round.py): every
+   probed-but-unranked brief becomes an unverified Stage-3 spare
+   (source-interleaved, cached `_probe_art` reused). Promotion still runs
+   body/image verify + the full safety vet per spare — deeper pool, same
+   gates.
+2. **Per-category degraded publish** — `_split_publishable` + pack merge
+   mode (reuses PR #40 machinery): fresh categories publish; a still-thin
+   category keeps its current live content from latest.zip; loud warning
+   in telemetry/digest. Only all-categories-thin refuses to publish.
+   Degraded publishes don't stamp thin cats' sources as shipped.
+
+## Invariant
+
+- A single category's failure must never block publishing the others,
+  and must never require a full re-run.
+- Deepening the backfill pool must not bypass verify/safety gates.
+
+## Pinning test
+
+`python -m pipeline.test_backfill_degrade` —
+`test_unpicked_probe_spares_excludes_ranked_and_interleaves`,
+`test_split_publishable_mixed`.
+
+## Related
+
+- `docs/bugs/2026-07-08-probe-cap-starves-low-priority-sources.md` — the
+  probe interleave these spares inherit.
+- PR #40 partial-category run — the merge machinery reused here.

--- a/docs/bugs/INDEX.md
+++ b/docs/bugs/INDEX.md
@@ -63,3 +63,4 @@ you must not break.
   lives in. The spec tells you the *intended* shape; the bug record
   tells you *where reality diverged and what saved us*.
 | 2026-07-08 | [probe-cap-starves-low-priority-sources](2026-07-08-probe-cap-starves-low-priority-sources.md) | pipeline | BBC got 0 probe slots: Stage-1.5 cap ate briefs in source-priority order; fix = round-robin interleave + per-source funnel telemetry | fixed |
+| 2026-07-08 | [thin-category-sinks-whole-publish](2026-07-08-thin-category-sinks-whole-publish.md) | pipeline | 1 thin category aborted the whole publish + backfill only saw curator's 5 ranks; fix = probe-brief deep spares + per-category degraded publish via merge mode | fixed |

--- a/pipeline/full_round.py
+++ b/pipeline/full_round.py
@@ -859,6 +859,48 @@ def verify_picks_lazy(ranked_by_cat: dict[str, list[dict]],
     return out
 
 
+def _unpicked_probe_spares(briefs: list[dict], ranked: list[dict]) -> list[dict]:
+    """Deep backfill pool (2026-07-08): the curator ranks only 5 per cat,
+    so after verify/safety attrition a category could starve while
+    probe-kept briefs sat unused — one thin category then aborted the
+    whole publish. Turn every probed-but-unranked brief into an
+    unverified Stage-3 spare (source-interleaved). Each still passes
+    body/image verify + the full safety vet in promote_spare_and_rewrite
+    before it can ship — this deepens the pool, it does not lower gates."""
+    used_keys = set()
+    for r in ranked:
+        b = r.get("brief") or {}
+        used_keys.add(b.get("link") or b.get("title") or id(b))
+    leftovers = [b for b in briefs
+                 if (b.get("link") or b.get("title") or id(b)) not in used_keys]
+    out: list[dict] = []
+    for i, b in enumerate(_interleave_by_source(leftovers), start=1):
+        src = b.get("_source")
+        if src is None:
+            continue
+        out.append({
+            "_unverified_spare": True,
+            "source": src,
+            "_winner_brief": b,
+            "_rank": f"probe+{i}",
+            "_curator_id": None,
+        })
+    return out
+
+
+def _split_publishable(final_stories_by_cat: dict,
+                       min_per_cat: int = 2) -> tuple[list[str], list[str]]:
+    """Partition categories into (fresh_ok, too_thin) for the pack step.
+    A thin category no longer sinks the whole bundle — pack runs in merge
+    mode publishing the fresh ones while the thin one keeps its current
+    live content."""
+    ok: list[str] = []
+    thin: list[str] = []
+    for cat, stories in final_stories_by_cat.items():
+        (ok if len(stories) >= min_per_cat else thin).append(cat)
+    return ok, thin
+
+
 def promote_spare_and_rewrite(
     cat: str,
     spares: list[dict],
@@ -1766,6 +1808,15 @@ def main_mega() -> None:
         log.info("=== MEGA verify body + og:image on rank 1-4 ===")
         vstats: dict = {}
         out = verify_picks_lazy(ranked_by_cat, max_top=4, stats=vstats)
+        # Deep backfill: probed-but-unranked briefs join the spare pool so
+        # Stage-3 promotion can dig past the curator's 5 ranks instead of
+        # starving the category.
+        for cat, briefs in briefs_by_cat.items():
+            extra = _unpicked_probe_spares(briefs, ranked_by_cat.get(cat) or [])
+            if extra:
+                out.setdefault(cat, []).extend(extra)
+                log.info("  [%s] +%d probe-pool spares for Stage-3 backfill",
+                         cat, len(extra))
         verified_counts = {c: sum(1 for s in v if not s.get("_unverified_spare"))
                            for c, v in out.items()}
         _set_phase("verify", t0, verified=verified_counts, per_source=vstats)
@@ -1977,9 +2028,24 @@ def main_mega() -> None:
     log.info("=== PACK + UPLOAD ZIP ===")
     upload_ok = False
     upload_err: str | None = None
+    ok_cats, thin_cats = _split_publishable(final_stories_by_cat)
     try:
         from .pack_and_upload import main as _pack_upload
-        if partial_cats:
+        if thin_cats and not ok_cats:
+            # Nothing publishable at all — refuse; site keeps its bundle.
+            raise SystemExit(
+                f"no publishable category (all <2 stories): {thin_cats}")
+        if thin_cats:
+            # Degraded publish: ship the fresh categories, keep the thin
+            # one's current live content (merge mode). No more one-thin-
+            # category-sinks-the-whole-bundle full re-runs.
+            telemetry["warnings"].append(
+                f"degraded publish — thin: {', '.join(thin_cats)} kept "
+                f"previous live content; fresh: {', '.join(ok_cats)}")
+            log.warning("degraded publish — thin %s keep live content; "
+                        "publishing fresh %s via merge", thin_cats, ok_cats)
+            os.environ["PACK_MERGE_CATEGORIES"] = ",".join(ok_cats)
+        elif partial_cats:
             # Merge mode: pack splices the other categories' content from
             # the live latest.zip; validation still gates the publish.
             os.environ["PACK_MERGE_CATEGORIES"] = ",".join(partial_cats)
@@ -1999,8 +2065,11 @@ def main_mega() -> None:
                     "telemetry": telemetry}
         if upload_ok:
             # Rotation stamping moved here from persist_to_supabase: only a
-            # DEPLOYED bundle counts as "used" for source rotation.
-            stamp_shipped_sources(final_stories_by_cat)
+            # DEPLOYED bundle counts as "used" for source rotation. On a
+            # degraded publish, a thin category's stories did NOT deploy.
+            deployed_by_cat = {c: s for c, s in final_stories_by_cat.items()
+                               if c not in thin_cats}
+            stamp_shipped_sources(deployed_by_cat)
             terminal["status"] = ("completed_with_warnings" if telemetry["warnings"]
                                    else "completed")
             terminal["notes"] = (f"stories persisted: {count}; deployed "

--- a/pipeline/test_backfill_degrade.py
+++ b/pipeline/test_backfill_degrade.py
@@ -1,0 +1,83 @@
+"""Tests for deep backfill + per-category degraded publish (2026-07-08).
+
+Owner complaint: "有一些文章没有,就导致整个 reject" — one thin category
+aborted the WHOLE publish (SystemExit at pack validation) and forced a
+full re-run, even though probe had kept 10 briefs and the curator only
+ranked 5 (the other 5 were silently discarded).
+
+Fix:
+  1. _unpicked_probe_spares — probed-but-unranked briefs become Stage-3
+     spares (source-interleaved). Each still passes body/image verify +
+     the full safety vet before it can ship.
+  2. _split_publishable — pack decides per category: fresh cats publish,
+     a still-thin cat keeps its current live content via merge mode;
+     only all-cats-thin refuses to publish at all.
+
+Run: python -m pipeline.test_backfill_degrade   (also works under pytest)
+"""
+from __future__ import annotations
+
+from pipeline import full_round as fr
+
+
+class _Src:
+    def __init__(self, name): self.name = name
+
+
+def _brief(src_name, link):
+    return {"title": f"t-{link}", "link": link,
+            "_source_name": src_name, "_source": _Src(src_name),
+            "_probe_art": {"word_count": 500}}
+
+
+# ── 1. deep backfill pool ──
+
+def test_unpicked_probe_spares_excludes_ranked_and_interleaves():
+    briefs = [_brief("A", "a1"), _brief("A", "a2"),
+              _brief("B", "b1"), _brief("B", "b2"),
+              _brief("C", "c1")]
+    ranked = [{"id": 1, "rank": 1, "brief": briefs[0]},   # a1 ranked
+              {"id": 2, "rank": 2, "brief": briefs[2]}]   # b1 ranked
+    spares = fr._unpicked_probe_spares(briefs, ranked)
+    links = [s["_winner_brief"]["link"] for s in spares]
+    assert set(links) == {"a2", "b2", "c1"}          # ranked ones excluded
+    # Source-interleaved: three distinct sources lead in first-seen order.
+    assert [s["source"].name for s in spares] == ["A", "B", "C"]
+    for s in spares:
+        assert s["_unverified_spare"] is True
+        assert s["source"].name == s["_winner_brief"]["_source_name"]
+        assert s["_winner_brief"]["_probe_art"]["word_count"] == 500
+
+
+def test_unpicked_probe_spares_empty_cases():
+    assert fr._unpicked_probe_spares([], []) == []
+    b = _brief("A", "a1")
+    assert fr._unpicked_probe_spares([b], [{"id": 1, "brief": b}]) == []
+
+
+# ── 2. per-category publishable split ──
+
+def test_split_publishable_mixed():
+    final = {"News": [1], "Science": [1, 2, 3], "Fun": [1, 2]}
+    ok, thin = fr._split_publishable(final)
+    assert ok == ["Science", "Fun"] and thin == ["News"]
+
+
+def test_split_publishable_all_ok_and_all_thin():
+    ok, thin = fr._split_publishable({"News": [1, 2], "Fun": [1, 2, 3]})
+    assert ok == ["News", "Fun"] and thin == []
+    ok2, thin2 = fr._split_publishable({"News": [], "Fun": [1]})
+    assert ok2 == [] and thin2 == ["News", "Fun"]
+
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"  PASS {fn.__name__}")
+    print(f"OK — {len(fns)} tests passed")
+
+
+if __name__ == "__main__":
+    _run_all()


### PR DESCRIPTION
Owner: one missing category should never reject the whole publish — with 4 News sources there should always be 3 qualified articles, and a shortfall must not require a full pipeline re-run.

1. **Deep backfill**: probe keeps 10 briefs/cat but the curator ranks 5 — the rest were discarded. They now become Stage-3 spares (source-interleaved, cached bodies reused). Every promotion still passes body/image verify + the full independent safety vet: deeper pool, same gates.
2. **Degraded publish**: if a category still ends <2, pack reuses the #40 merge machinery — fresh categories publish, the thin one keeps its current live content from latest.zip, loud warning in telemetry + digest. Only all-categories-thin refuses to publish (site keeps old bundle). Thin-cat sources are not stamped as shipped.

Tests: `pipeline/test_backfill_degrade.py` (4) + all suites green (38 total).

**Backend-only — no auto-deploy.** Takes effect at the next daily run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)