### PR TITLE
feat(pack): carry-over top-up — a category always ships 3 articles

### DIFF
--- a/docs/bugs/2026-07-08-thin-category-sinks-whole-publish.md
+++ b/docs/bugs/2026-07-08-thin-category-sinks-whole-publish.md
@@ -56,3 +56,13 @@ PR: fix/deep-backfill-degraded-publish.
 - `docs/bugs/2026-07-08-probe-cap-starves-low-priority-sources.md` — the
   probe interleave these spares inherit.
 - PR #40 partial-category run — the merge machinery reused here.
+
+## Follow-up (same day) — pack-time carry-over top-up
+
+Owner refinement: a category should ALWAYS ship 3 — after cross-source
+backfill, borrow from the previous live bundle. `_topup_thin_categories`
+(pack_and_upload.py) appends previous-bundle stories (listings + payloads
++ images + PDFs, id-deduped) to any 1-2-story category until 3; a 0-story
+category still keeps old content wholesale; only all-0 refuses to publish.
+main_mega threshold moved to min_per_cat=1. Pure file ops, no LLM, gates
+unchanged. Tests: pipeline/test_pack_topup.py.

--- a/pipeline/full_round.py
+++ b/pipeline/full_round.py
@@ -2028,22 +2028,31 @@ def main_mega() -> None:
     log.info("=== PACK + UPLOAD ZIP ===")
     upload_ok = False
     upload_err: str | None = None
-    ok_cats, thin_cats = _split_publishable(final_stories_by_cat)
+    # min_per_cat=1: a 1-2-story category still publishes fresh — pack
+    # tops it up to 3 with carried-over stories from the previous bundle
+    # (owner rule 2026-07-08: a category always ships 3 — other sources
+    # first, then borrow from the previous day). Only a 0-story category
+    # keeps the previous live content wholesale.
+    ok_cats, thin_cats = _split_publishable(final_stories_by_cat, min_per_cat=1)
+    short_cats = [c for c in ok_cats
+                  if len(final_stories_by_cat.get(c) or []) < 3]
     try:
         from .pack_and_upload import main as _pack_upload
         if thin_cats and not ok_cats:
             # Nothing publishable at all — refuse; site keeps its bundle.
             raise SystemExit(
-                f"no publishable category (all <2 stories): {thin_cats}")
+                f"no publishable category (all 0 stories): {thin_cats}")
         if thin_cats:
-            # Degraded publish: ship the fresh categories, keep the thin
-            # one's current live content (merge mode). No more one-thin-
-            # category-sinks-the-whole-bundle full re-runs.
             telemetry["warnings"].append(
-                f"degraded publish — thin: {', '.join(thin_cats)} kept "
-                f"previous live content; fresh: {', '.join(ok_cats)}")
-            log.warning("degraded publish — thin %s keep live content; "
+                f"degraded publish — {', '.join(thin_cats)} kept previous "
+                f"live content; fresh: {', '.join(ok_cats)}")
+            log.warning("degraded publish — %s keep live content; "
                         "publishing fresh %s via merge", thin_cats, ok_cats)
+        if short_cats:
+            telemetry["warnings"].append(
+                f"top-up publish — {', '.join(short_cats)} shipped <3 fresh; "
+                "pack carries previous-bundle stories over to fill 3")
+        if thin_cats:
             os.environ["PACK_MERGE_CATEGORIES"] = ",".join(ok_cats)
         elif partial_cats:
             # Merge mode: pack splices the other categories' content from

--- a/pipeline/pack_and_upload.py
+++ b/pipeline/pack_and_upload.py
@@ -393,6 +393,92 @@ def _overlay_fresh_categories(old_root: Path, fresh_root: Path,
                  cat, len(new_ids), len(old_ids - new_ids))
 
 
+def _derive_pack_plan(local_counts: dict[str, int],
+                      merge_env_cats: set[str] | None = None,
+                      ) -> tuple[set[str], set[str], set[str]]:
+    """Decide per category what to publish, from local listing article
+    counts (middle level). Returns (fresh, short, keep_old):
+      fresh:    cats publishing local content (≥1 article; restricted to
+                merge_env_cats when a partial run set them)
+      short:    fresh cats with <3 articles → top up from previous bundle
+      keep_old: cats keeping the previous live content entirely
+    Owner rule (2026-07-08): a category should always ship 3 — dig other
+    sources first (Stage-3 backfill), then carry over from the previous
+    bundle; only a 0-fresh category keeps old content wholesale."""
+    pool = set(merge_env_cats) if merge_env_cats else set(local_counts)
+    fresh = {c for c in pool if local_counts.get(c, 0) >= 1}
+    short = {c for c in fresh if local_counts.get(c, 0) < 3}
+    keep_old = set(CATS) - fresh
+    return fresh, short, keep_old
+
+
+def _topup_thin_categories(final_root: Path, old_root: Path,
+                           target: int = 3) -> dict[str, list[str]]:
+    """Append carried-over stories from the previous live bundle to any
+    category whose listings have 1..target-1 articles, until `target`.
+    Copies the carried stories' detail payloads / images / PDFs. Pure
+    file ops — no LLM, no gate changes. Returns {cat: [carried ids]}."""
+    carried: dict[str, list[str]] = {}
+    for cat in CATS:
+        mid = final_root / "payloads" / f"articles_{cat}_middle.json"
+        old_mid = old_root / "payloads" / f"articles_{cat}_middle.json"
+        if not (mid.is_file() and old_mid.is_file()):
+            continue
+        try:
+            fresh_arts = json.loads(mid.read_text()).get("articles") or []
+            old_arts = json.loads(old_mid.read_text()).get("articles") or []
+        except Exception as e:  # noqa: BLE001
+            log.warning("topup: [%s] unreadable listing (%s) — skipped", cat, e)
+            continue
+        if not fresh_arts or len(fresh_arts) >= target:
+            continue
+        fresh_ids = {a.get("id") for a in fresh_arts}
+        cand_ids = [a.get("id") for a in old_arts
+                    if a.get("id") and a["id"] not in fresh_ids]
+        cand_ids = cand_ids[: target - len(fresh_arts)]
+        if not cand_ids:
+            continue
+        # Splice into every level's listing (old bundle has all levels).
+        for lvl in ("easy", "middle", "cn"):
+            fp = final_root / "payloads" / f"articles_{cat}_{lvl}.json"
+            op = old_root / "payloads" / f"articles_{cat}_{lvl}.json"
+            if not (fp.is_file() and op.is_file()):
+                continue
+            fdoc = json.loads(fp.read_text())
+            by_id = {a.get("id"): a
+                     for a in json.loads(op.read_text()).get("articles") or []}
+            arts = fdoc.get("articles") or []
+            for cid in cand_ids:
+                if cid in by_id and all(a.get("id") != cid for a in arts):
+                    arts.append(by_id[cid])
+            fdoc["articles"] = arts[:target]
+            fp.write_text(json.dumps(fdoc, ensure_ascii=False))
+        # Carry the artifacts.
+        img_names: set[str] = set()
+        for a in old_arts:
+            if a.get("id") in cand_ids and a.get("image_url"):
+                img_names.add(Path(a["image_url"]).name)
+        for cid in cand_ids:
+            src = old_root / "article_payloads" / f"payload_{cid}"
+            if src.is_dir():
+                dst = final_root / "article_payloads" / f"payload_{cid}"
+                shutil.rmtree(dst, ignore_errors=True)
+                shutil.copytree(src, dst)
+            for pdf in (old_root / "article_pdfs").glob(f"{cid}-*.pdf"):
+                dst_dir = final_root / "article_pdfs"
+                dst_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(pdf, dst_dir / pdf.name)
+        for img in img_names:
+            src = old_root / "article_images" / img
+            if src.is_file():
+                dst_dir = final_root / "article_images"
+                dst_dir.mkdir(parents=True, exist_ok=True)
+                shutil.copy2(src, dst_dir / img)
+        carried[cat] = cand_ids
+        log.info("topup: [%s] carried %s over from previous bundle", cat, cand_ids)
+    return carried
+
+
 DATED_ZIP_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})\.zip$")
 DATED_MANIFEST_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})-manifest\.json$")
 DATED_DIR_RE = re.compile(r"^(\d{4}-\d{2}-\d{2})$")
@@ -604,10 +690,12 @@ def main() -> None:
     republish = os.environ.get("PACK_REPUBLISH_ONLY") == "1"
     sb = create_client(os.environ["SUPABASE_URL"], os.environ["SUPABASE_SERVICE_KEY"])
 
-    # Merge mode (partial category run): fresh content for SOME categories
-    # is on local disk; everything else comes from the live latest.zip.
-    # Full validation still gates the publish — a bad merge refuses to
-    # upload and the site keeps its current bundle.
+    # Merge / top-up planning: fresh categories publish from local disk;
+    # a short category (1-2 articles) is topped up to 3 with carried-over
+    # stories from the previous live bundle; a 0-fresh category keeps the
+    # previous live content entirely. Full validation still gates the
+    # publish — a bad merge refuses to upload and the site keeps its
+    # current bundle.
     merge_env = (os.environ.get("PACK_MERGE_CATEGORIES") or "").strip()
     merge_cats = {c.strip().lower() for c in merge_env.split(",") if c.strip()}
     if merge_cats:
@@ -617,42 +705,56 @@ def main() -> None:
         unknown = merge_cats - set(CATS)
         if unknown:
             raise SystemExit(f"PACK_MERGE_CATEGORIES unknown: {sorted(unknown)}")
-        import tempfile
-        merge_root = Path(tempfile.mkdtemp(prefix="pack_merge_"))
-        try:
-            blob = sb.storage.from_(BUCKET).download("latest.zip")
-        except Exception as e:  # noqa: BLE001
-            # No fallback: local disk only has the fresh categories, so
-            # packing local-only would ship a bundle missing the rest.
-            raise SystemExit(f"merge mode needs the live latest.zip: {e}")
-        with zipfile.ZipFile(BytesIO(blob)) as zf:
-            for info in zf.infolist():
-                top = info.filename.split("/", 1)[0]
-                if top in CONTENT_DIRS:
-                    zf.extract(info, merge_root)
-        _overlay_fresh_categories(merge_root, WEB, merge_cats)
-        validate_bundle(today, content_root=merge_root)
-        body = build_zip(content_root=merge_root)
-        manifest = build_manifest(today, body, content_root=merge_root)
-        manifest_bytes = json.dumps(manifest, ensure_ascii=False, indent=2).encode()
-        check_not_overwriting_newer(sb)
-        for key in (f"{today}.zip", "latest.zip"):
-            sb.storage.from_(BUCKET).upload(
-                path=key, file=body,
-                file_options={"content-type": "application/zip", "upsert": "true"})
-            log.info("uploaded %s", key)
-        for key in (f"{today}-manifest.json", "latest-manifest.json"):
-            sb.storage.from_(BUCKET).upload(
-                path=key, file=manifest_bytes,
-                file_options={"content-type": "application/json", "upsert": "true"})
-            log.info("uploaded %s", key)
-        try:
-            upload_dated_flat_files(sb, today, bundle=body)
-        except Exception as e:  # noqa: BLE001
-            log.warning("dated-flat upload failed (non-fatal): %s", e)
-        log.info("merge publish done: %s replaced · stories=%d",
-                 sorted(merge_cats), manifest["story_count"])
-        return
+
+    content_root: Path | None = None   # None → pack straight from WEB
+    if not republish:
+        local_counts: dict[str, int] = {}
+        for cat in CATS:
+            p = WEB / "payloads" / f"articles_{cat}_middle.json"
+            if p.is_file():
+                try:
+                    local_counts[cat] = len(
+                        json.loads(p.read_text()).get("articles") or [])
+                except Exception:  # noqa: BLE001
+                    local_counts[cat] = 0
+        fresh, short, keep_old = _derive_pack_plan(local_counts,
+                                                   merge_cats or None)
+        if not fresh:
+            raise SystemExit("no fresh category content on disk — "
+                             "nothing to publish")
+        if keep_old or short:
+            import tempfile
+            old_root = Path(tempfile.mkdtemp(prefix="pack_old_"))
+            try:
+                blob = sb.storage.from_(BUCKET).download("latest.zip")
+            except Exception as e:  # noqa: BLE001
+                if keep_old or any(local_counts.get(c, 0) < 2 for c in fresh):
+                    # Can't ship a bundle with a category-shaped hole.
+                    raise SystemExit(
+                        f"pack needs the live latest.zip for merge/top-up: {e}")
+                log.warning("top-up skipped — no previous bundle (%s); "
+                            "shipping %s with <3 articles", e, sorted(short))
+            else:
+                with zipfile.ZipFile(BytesIO(blob)) as zf:
+                    for info in zf.infolist():
+                        top = info.filename.split("/", 1)[0]
+                        if top in CONTENT_DIRS:
+                            zf.extract(info, old_root)
+                # Final bundle starts as the old content; fresh categories
+                # overlay it; short ones borrow back from old_root.
+                merge_root = Path(tempfile.mkdtemp(prefix="pack_merge_"))
+                for d in CONTENT_DIRS:
+                    if (old_root / d).is_dir():
+                        shutil.copytree(old_root / d, merge_root / d)
+                _overlay_fresh_categories(merge_root, WEB, fresh)
+                carried = _topup_thin_categories(merge_root, old_root)
+                if keep_old:
+                    log.warning("pack: %s keep previous live content",
+                                sorted(keep_old))
+                if carried:
+                    log.warning("pack: topped up %s with carried-over stories",
+                                {c: len(v) for c, v in carried.items()})
+                content_root = merge_root
 
     if republish:
         # Pull current latest.zip and extract CONTENT_DIRS to a temp dir
@@ -676,10 +778,11 @@ def main() -> None:
             content_root = None
         body = build_zip(content_root=content_root)
     else:
-        validate_bundle(today)
-        body = build_zip()
+        validate_bundle(today, content_root=content_root)
+        body = build_zip(content_root=content_root)
 
-    manifest = build_manifest(today, body)
+    manifest = build_manifest(today, body,
+                              content_root=None if republish else content_root)
     manifest_bytes = json.dumps(manifest, ensure_ascii=False, indent=2).encode()
     if not republish:
         check_not_overwriting_newer(sb)
@@ -719,7 +822,10 @@ def main() -> None:
     # present, so DatePopover never advertises a date whose payloads 404.
     today_flat_ok = False
     try:
-        n = upload_dated_flat_files(sb, today)
+        # Extract from the just-built zip so dated flats always match the
+        # published bundle exactly (incl. merged/topped-up categories and
+        # scrubbed detail payloads).
+        n = upload_dated_flat_files(sb, today, bundle=body)
         today_flat_ok = n > 0
     except Exception as e:  # noqa: BLE001
         log.warning("dated-flat upload failed (non-fatal for today's deploy): %s", e)

--- a/pipeline/test_pack_topup.py
+++ b/pipeline/test_pack_topup.py
@@ -1,0 +1,132 @@
+"""Tests for pack-time carry-over top-up (2026-07-08).
+
+Owner design: a category must always ship 3 articles —
+  1. dig deeper across sources (Stage-3 deep backfill, #41), and
+  2. if still short at pack time, carry stories over from the previous
+     live bundle until the category has 3 again.
+
+`_derive_pack_plan` decides per category: publish fresh / top up / keep
+old. `_topup_thin_categories` appends previous-bundle stories (listings +
+detail payloads + images + PDFs) to a short category. Pure file ops — no
+LLM calls, no gate changes.
+
+Run: python -m pipeline.test_pack_topup   (also works under pytest)
+"""
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from pipeline import pack_and_upload as pk
+
+
+# ── 1. pack plan ──
+
+def test_plan_all_full_needs_nothing():
+    fresh, short, keep = pk._derive_pack_plan(
+        {"news": 3, "science": 3, "fun": 3})
+    assert fresh == {"news", "science", "fun"}
+    assert short == set() and keep == set()
+
+
+def test_plan_short_and_empty_categories():
+    fresh, short, keep = pk._derive_pack_plan(
+        {"news": 1, "science": 3, "fun": 0})
+    assert fresh == {"news", "science"}
+    assert short == {"news"}          # 1-2 fresh → top up to 3
+    assert keep == {"fun"}            # 0 fresh → keep previous live content
+
+
+def test_plan_env_restricts_fresh_set():
+    # Partial run: only News is fresh even if stale local listings exist.
+    fresh, short, keep = pk._derive_pack_plan(
+        {"news": 2, "science": 3}, merge_env_cats={"news"})
+    assert fresh == {"news"} and short == {"news"}
+    assert keep == {"science", "fun"}
+
+
+# ── 2. carry-over top-up ──
+
+def _listing(ids_imgs):
+    return json.dumps({"articles": [
+        {"id": i, "title": f"t-{i}", "summary": "s",
+         "image_url": f"article_images/{img}"} for i, img in ids_imgs]})
+
+
+def _seed(root: Path, cat: str, ids_imgs) -> None:
+    (root / "payloads").mkdir(parents=True, exist_ok=True)
+    for lvl in ("easy", "middle", "cn"):
+        (root / "payloads" / f"articles_{cat}_{lvl}.json").write_text(
+            _listing(ids_imgs))
+    for sid, img in ids_imgs:
+        d = root / "article_payloads" / f"payload_{sid}"
+        d.mkdir(parents=True, exist_ok=True)
+        (d / "middle.json").write_text("{}")
+        (root / "article_images").mkdir(parents=True, exist_ok=True)
+        (root / "article_images" / img).write_bytes(b"x")
+        (root / "article_pdfs").mkdir(parents=True, exist_ok=True)
+        (root / "article_pdfs" / f"{sid}-middle.pdf").write_bytes(b"p")
+
+
+def test_topup_fills_short_category_from_old_bundle():
+    with tempfile.TemporaryDirectory() as t1, tempfile.TemporaryDirectory() as t2:
+        final, old = Path(t1), Path(t2)
+        _seed(final, "news", [("today-1", "new1.webp")])            # 1 fresh
+        _seed(old, "news", [("yday-1", "o1.webp"), ("yday-2", "o2.webp"),
+                            ("yday-3", "o3.webp")])
+        carried = pk._topup_thin_categories(final, old)
+        assert carried == {"news": ["yday-1", "yday-2"]}
+        for lvl in ("easy", "middle", "cn"):
+            doc = json.loads(
+                (final / "payloads" / f"articles_news_{lvl}.json").read_text())
+            assert [a["id"] for a in doc["articles"]] == \
+                ["today-1", "yday-1", "yday-2"]     # fresh first, then carried
+        # Carried artifacts copied over.
+        assert (final / "article_payloads" / "payload_yday-1" / "middle.json").is_file()
+        assert (final / "article_images" / "o2.webp").is_file()
+        assert (final / "article_pdfs" / "yday-1-middle.pdf").is_file()
+        # Not-carried old story stays out.
+        assert not (final / "article_payloads" / "payload_yday-3").exists()
+
+
+def test_topup_skips_full_and_empty_categories():
+    with tempfile.TemporaryDirectory() as t1, tempfile.TemporaryDirectory() as t2:
+        final, old = Path(t1), Path(t2)
+        _seed(final, "science", [("s1", "s1.webp"), ("s2", "s2.webp"),
+                                 ("s3", "s3.webp")])                # full
+        _seed(old, "science", [("os1", "os1.webp")])
+        _seed(old, "fun", [("of1", "of1.webp")])                    # no fresh fun
+        carried = pk._topup_thin_categories(final, old)
+        assert carried == {}
+        doc = json.loads(
+            (final / "payloads" / "articles_science_middle.json").read_text())
+        assert len(doc["articles"]) == 3 and doc["articles"][0]["id"] == "s1"
+
+
+def test_topup_never_duplicates_ids():
+    with tempfile.TemporaryDirectory() as t1, tempfile.TemporaryDirectory() as t2:
+        final, old = Path(t1), Path(t2)
+        # Fresh already contains one of the old ids (same-slot overwrite).
+        _seed(final, "news", [("shared-1", "n1.webp"), ("today-2", "n2.webp")])
+        _seed(old, "news", [("shared-1", "o1.webp"), ("yday-2", "o2.webp")])
+        carried = pk._topup_thin_categories(final, old)
+        assert carried == {"news": ["yday-2"]}
+        doc = json.loads(
+            (final / "payloads" / "articles_news_middle.json").read_text())
+        ids = [a["id"] for a in doc["articles"]]
+        assert ids == ["shared-1", "today-2", "yday-2"]
+        assert len(ids) == len(set(ids))
+
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"  PASS {fn.__name__}")
+    print(f"OK — {len(fns)} tests passed")
+
+
+if __name__ == "__main__":
+    _run_all()


### PR DESCRIPTION
Owner design: when a category comes up short (like News=1 this morning), (1) dig deeper across the other sources — done in #41 — and (2) if still short at pack time, carry stories over from the previous live bundle until the category shows 3 again. Result: kids always see 3 per category; a fresh article never gets held back by its neighbors.

- `_derive_pack_plan`: fresh / short / keep-old per category from local listing counts (env-restricted on partial runs)
- `_topup_thin_categories`: appends previous-bundle stories (3 level listings + detail payloads + images + PDFs, id-deduped) to any 1-2-story category
- 0-story category keeps previous live content wholesale; only all-0 refuses to publish (site keeps old bundle)
- merged publishes now run the full publish tail (manifest, dated flats from the built zip, archive-index, retention)
- telemetry warnings: "top-up publish — …" / "degraded publish — …" surface in the daily digest

Tests: `pipeline/test_pack_topup.py` (6) + all suites green (44 total). **Backend-only — no auto-deploy**; takes effect next daily run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)