### PR TITLE
feat(curator): cap one subject per News top 3 (no more 3 Trump stories)

### DIFF
--- a/docs/bugs/2026-07-08-news-subject-cap.md
+++ b/docs/bugs/2026-07-08-news-subject-cap.md
@@ -1,0 +1,47 @@
+# 2026-07-08 — cap one subject per News top 3 (3 Trump stories shipped)
+
+**Severity:** medium
+**Area:** pipeline (mega curator diversity)
+**Status:** fixed
+**Keywords:** subject, cluster_id, topic diversity, curator, _enforce_top3_subject_diversity, News, entity cap
+
+## Symptom
+
+Owner: yesterday all 3 News stories were Trump-related. The curator's
+within-cat "prefer different clusters" is soft, and cluster_id groups by
+*story* (a summit, an election ruling, a tariff = 3 clusters) not by
+*person*, so three Trump stories passed as "diverse".
+
+## Fix
+
+PR: feat/news-subject-cap.
+
+1. Curator now tags each pick with a `subject` = the dominant named
+   person/org ("" if none) — coarser than cluster_id. Prompt gains a
+   HARD RULE: a non-empty subject may appear only ONCE in the News top 3
+   ("don't ship three Trump stories"), fill the rest with different
+   subjects.
+2. `_enforce_top3_subject_diversity` (mega_curator.py) — deterministic
+   backstop mirroring `_enforce_top3_source_diversity`, scoped to News:
+   swaps a repeated-subject pick out of the top 3 for a rank-4/5 spare
+   with a different subject, preferring one that also keeps 3 distinct
+   sources; falls back to any different-subject spare (subject cap wins
+   over source diversity on conflict). Empty subject never collides.
+   Degrades cleanly + warns when the pool truly has no other subject;
+   deep backfill / carry-over (#41/#42) then fill from other sources.
+
+## Invariant
+
+- News ships at most one story per non-empty subject in its top 3.
+  Scope is News-only by owner choice; extend cap_categories to widen.
+
+## Pinning test
+
+`python -m pipeline.test_subject_cap` — esp.
+`test_caps_repeated_subject_and_fills_from_spares`,
+`test_empty_subject_never_counts_as_duplicate`.
+
+## Related
+
+- `pipeline/mega_curator.py::_enforce_top3_source_diversity` — the
+  source-diversity backstop this mirrors and runs after.

--- a/docs/bugs/INDEX.md
+++ b/docs/bugs/INDEX.md
@@ -64,3 +64,4 @@ you must not break.
   tells you *where reality diverged and what saved us*.
 | 2026-07-08 | [probe-cap-starves-low-priority-sources](2026-07-08-probe-cap-starves-low-priority-sources.md) | pipeline | BBC got 0 probe slots: Stage-1.5 cap ate briefs in source-priority order; fix = round-robin interleave + per-source funnel telemetry | fixed |
 | 2026-07-08 | [thin-category-sinks-whole-publish](2026-07-08-thin-category-sinks-whole-publish.md) | pipeline | 1 thin category aborted the whole publish + backfill only saw curator's 5 ranks; fix = probe-brief deep spares + per-category degraded publish via merge mode | fixed |
+| 2026-07-08 | [news-subject-cap](2026-07-08-news-subject-cap.md) | pipeline | 3 Trump stories shipped: cluster_id groups by story not person; fix = curator `subject` tag + deterministic ≤1-subject cap on News top 3 | fixed |

--- a/pipeline/mega_curator.py
+++ b/pipeline/mega_curator.py
@@ -43,12 +43,24 @@ ALGORITHM (internal, don't output intermediate work):
 
   2. CLUSTER: group candidates covering the same real-world story into
      topic clusters. Pick AT MOST ONE candidate per cluster across all
-     3 categories combined.
+     3 categories combined. Also tag each pick with a `subject` — the
+     ONE dominant named person or organization the story centers on
+     (e.g. "Donald Trump", "NASA", "Taylor Swift"), or "" if no single
+     person/org dominates. `subject` is COARSER than cluster_id: three
+     different Trump stories (a summit, an election ruling, a tariff)
+     share subject "Donald Trump" even though their cluster_ids differ.
 
   3. PICK 5 PER CAT, RANKED:
      - Prefer high interest_peak (max of importance / fun / kid_appeal)
        AND low safety_total.
      - Prefer DIFFERENT topic clusters within a cat.
+     - HARD RULE — subject diversity in NEWS top 3: ranks 1, 2, 3 of
+       the News category MUST each have a DIFFERENT `subject` (a
+       non-empty subject may appear only ONCE in the News top 3). Do
+       NOT ship three stories about the same person — e.g. three Trump
+       stories. Keep the single strongest one and fill the other News
+       ranks with different-subject stories. Only repeat a subject if
+       News genuinely has no other qualifying story.
      - HARD RULE — source diversity in top 3: ranks 1, 2, 3 of each
        category MUST come from THREE DIFFERENT sources (different
        `src=` value). Only break this rule if the category has fewer
@@ -68,7 +80,7 @@ has the vet signal. Use SHORT integer scores, no totals/peaks, no prose.
 {
   "picks": {
     "News": [
-      {"rank":1,"id":N,"cluster_id":"<short>",
+      {"rank":1,"id":N,"cluster_id":"<short>","subject":"<person/org or empty>",
        "safety":{"violence":N,"sexual":N,"substance":N,"language":N,
                  "fear":N,"adult_themes":N,"distress":N,"bias":N},
        "interest":{"importance":N,"fun_factor":N,"kid_appeal":N}},
@@ -183,6 +195,7 @@ def mega_curate(
                 "safety": p.get("safety") or {},
                 "interest": p.get("interest") or {},
                 "cluster_id": p.get("cluster_id") or "",
+                "subject": (p.get("subject") or "").strip(),
             }
             vet[cid] = pick_vet
             out[cat].append({
@@ -194,11 +207,87 @@ def mega_curate(
             })
 
     out = _enforce_top3_source_diversity(out)
+    # Subject cap runs AFTER source diversity and prefers a spare that
+    # keeps 3 distinct sources, so it doesn't undo the source pass.
+    out = _enforce_top3_subject_diversity(out)
 
     for cat, picks in out.items():
         log.info("  curator [%s] %d ranked: %s", cat, len(picks),
                  ", ".join(f"rank{p['rank']}={p['source'].name}" for p in picks[:6]))
     return out, vet, reasoning
+
+
+def _enforce_top3_subject_diversity(
+    ranked_by_cat: dict[str, list[dict]],
+    cap_categories: tuple[str, ...] = ("News",),
+) -> dict[str, list[dict]]:
+    """Enforce: within the capped categories' top 3, a non-empty
+    `subject` (dominant person/org) appears at most ONCE — so News never
+    ships three stories about the same person (owner ask 2026-07-08:
+    "all 3 news were Trump"). Deterministic backstop for the prompt HARD
+    RULE, mirroring _enforce_top3_source_diversity.
+
+    Strategy per capped category: if a subject repeats in ranks 1-3, swap
+    the WORST-rank duplicate for a rank-4/5 spare with a DIFFERENT
+    subject — preferring a spare that also keeps 3 distinct sources, then
+    falling back to any different-subject spare (subject cap wins over
+    source diversity when they conflict). Empty subject never collides.
+    Degrades cleanly (leaves picks intact + warns) when the pool has no
+    other subject to offer; deep backfill / carry-over then fill from
+    other sources downstream."""
+    from collections import Counter
+
+    def _subj(p: dict) -> str:
+        return ((p.get("vet") or {}).get("subject") or "").strip()
+
+    for cat, picks in ranked_by_cat.items():
+        if cat not in cap_categories or len(picks) < 3:
+            continue
+        for _ in range(4):
+            top3 = picks[:3]
+            top3_subs = {_subj(p) for p in top3 if _subj(p)}
+            counter = Counter(_subj(p) for p in top3 if _subj(p))
+            dups = [s for s, c in counter.items() if c > 1]
+            if not dups:
+                break
+            dup_idx = max((i for i in range(3) if _subj(picks[i]) in dups),
+                          key=lambda i: picks[i]["rank"])
+
+            def _spare(keep_source: bool):
+                for j in range(3, len(picks)):
+                    if _subj(picks[j]) in top3_subs:
+                        continue                     # not a new subject
+                    if keep_source:
+                        new_srcs = [picks[i]["source"].name
+                                    for i in range(3) if i != dup_idx]
+                        new_srcs.append(picks[j]["source"].name)
+                        if len(set(new_srcs)) < 3:
+                            continue                 # would create a source dup
+                    return j
+                return None
+
+            spare_idx = _spare(keep_source=True)
+            if spare_idx is None:
+                spare_idx = _spare(keep_source=False)
+            if spare_idx is None:
+                log.warning("  [%s] subject-cap: subject %s repeats but no "
+                            "different-subject spare — top 3 stays "
+                            "(only %d distinct subjects in curator's top %d)",
+                            cat, dups,
+                            len({_subj(p) for p in picks if _subj(p)}),
+                            len(picks))
+                break
+
+            old, new = picks[dup_idx], picks[spare_idx]
+            log.info("  [%s] subject-cap swap: rank%d/%s (%s) ↔ rank%d/%s (%s)",
+                     cat, old["rank"], old["source"].name, _subj(old),
+                     new["rank"], new["source"].name, _subj(new))
+            old_rank, new_rank = old["rank"], new["rank"]
+            picks[dup_idx], picks[spare_idx] = new, old
+            picks[dup_idx]["rank"] = old_rank
+            picks[spare_idx]["rank"] = new_rank
+
+    return ranked_by_cat
 
 
 def _enforce_top3_source_diversity(

--- a/pipeline/test_subject_cap.py
+++ b/pipeline/test_subject_cap.py
@@ -1,0 +1,117 @@
+"""Tests for the per-subject cap in News pickup (2026-07-08).
+
+Owner ask: yesterday all 3 News stories were about Trump. Cap any single
+dominant subject (person/org) to ONE story in News's top 3, and fill the
+freed slots with different-subject candidates.
+
+Mechanism: the curator tags each pick with a `subject` (dominant named
+person/org, "" if none). `_enforce_top3_subject_diversity` is a
+deterministic backstop — mirrors `_enforce_top3_source_diversity` — that
+swaps a repeated-subject pick out of the top 3 for a different-subject
+spare. Scoped to News. Empty subject never collides (generic stories).
+
+Run: python -m pipeline.test_subject_cap   (also works under pytest)
+"""
+from __future__ import annotations
+
+from pipeline import mega_curator as mc
+
+
+class _Src:
+    def __init__(self, name): self.name = name
+
+
+def _pick(rank, subject, src):
+    return {"rank": rank, "id": rank, "source": _Src(src),
+            "brief": {}, "vet": {"subject": subject}}
+
+
+def _subs(picks):
+    return [p["vet"]["subject"]
+            for p in sorted(picks, key=lambda p: p["rank"])[:3]]
+
+
+def _srcs(picks):
+    return [p["source"].name
+            for p in sorted(picks, key=lambda p: p["rank"])[:3]]
+
+
+# ── 1. core cap ──
+
+def test_caps_repeated_subject_and_fills_from_spares():
+    picks = [_pick(1, "Donald Trump", "NPR"),
+             _pick(2, "Donald Trump", "BBC"),
+             _pick(3, "Donald Trump", "PBS"),
+             _pick(4, "Climate", "AlJazeera"),
+             _pick(5, "Space", "Reuters")]
+    out = mc._enforce_top3_subject_diversity({"News": picks})["News"]
+    subs = _subs(out)
+    assert subs.count("Donald Trump") == 1
+    assert len(set(subs)) == 3                 # 3 distinct subjects ship
+    # A diverse-source fill was available, so source diversity survives too.
+    assert len(set(_srcs(out))) == 3
+    assert len(out) == 5 and len({p["rank"] for p in out}) == 5
+
+
+def test_empty_subject_never_counts_as_duplicate():
+    # Two "no dominant subject" stories are NOT a collision.
+    picks = [_pick(1, "", "NPR"), _pick(2, "", "BBC"),
+             _pick(3, "Donald Trump", "PBS"),
+             _pick(4, "Climate", "AlJazeera"), _pick(5, "Space", "Reuters")]
+    out = mc._enforce_top3_subject_diversity({"News": picks})["News"]
+    assert _subs(out) == ["", "", "Donald Trump"]   # untouched
+
+
+# ── 2. scope: News only ──
+
+def test_non_news_categories_untouched():
+    picks = [_pick(1, "NASA", "A"), _pick(2, "NASA", "B"),
+             _pick(3, "NASA", "C"), _pick(4, "Ocean", "D"), _pick(5, "Bugs", "E")]
+    out = mc._enforce_top3_subject_diversity({"Science": [dict(p) for p in picks]})
+    assert _subs(out["Science"]) == ["NASA", "NASA", "NASA"]
+
+
+# ── 3. graceful degrade ──
+
+def test_no_diverse_spare_leaves_picks_intact():
+    picks = [_pick(i, "Donald Trump", s)
+             for i, s in enumerate(["NPR", "BBC", "PBS", "AlJazeera", "Reuters"], 1)]
+    out = mc._enforce_top3_subject_diversity({"News": picks})["News"]
+    # Nothing to swap to — degrades (still all Trump) but no crash / no loss.
+    assert len(out) == 5 and _subs(out).count("Donald Trump") == 3
+
+
+def test_prefers_spare_that_also_keeps_source_diversity():
+    # Two candidate fills differ in subject; only one keeps 3 distinct sources.
+    picks = [_pick(1, "Donald Trump", "NPR"),
+             _pick(2, "Donald Trump", "BBC"),
+             _pick(3, "Weather", "PBS"),
+             _pick(4, "Climate", "NPR"),        # different subject but source NPR (dup)
+             _pick(5, "Space", "Reuters")]      # different subject AND new source
+    out = mc._enforce_top3_subject_diversity({"News": picks})["News"]
+    subs = _subs(out)
+    assert subs.count("Donald Trump") == 1
+    assert len(set(_srcs(out))) == 3            # picked Reuters, not the NPR dup
+
+
+# ── 4. prompt carries the rule ──
+
+def test_prompt_has_subject_field_and_news_cap_rule():
+    p = mc.MEGA_CURATOR_SYSTEM_PROMPT
+    assert '"subject"' in p
+    assert "subject" in p.lower() and "News" in p
+    # names the failure mode so the model has an anchor
+    assert "one" in p.lower()
+
+
+def _run_all():
+    fns = [v for k, v in sorted(globals().items())
+           if k.startswith("test_") and callable(v)]
+    for fn in fns:
+        fn()
+        print(f"  PASS {fn.__name__}")
+    print(f"OK — {len(fns)} tests passed")
+
+
+if __name__ == "__main__":
+    _run_all()


### PR DESCRIPTION
Owner: yesterday all 3 News stories were Trump-related. `cluster_id` groups by *story* not *person*, so three different Trump stories (summit / ruling / tariff) passed as "diverse".

- Curator tags each pick with a `subject` (dominant person/org, "" if none) — coarser than cluster_id — and the prompt gains a HARD RULE: a non-empty subject may appear only ONCE in News top 3.
- `_enforce_top3_subject_diversity`: deterministic backstop (News-scoped, mirrors the source-diversity pass) — swaps a repeated-subject pick for a different-subject spare, preferring one that keeps 3 distinct sources. Empty subject never collides. Degrades cleanly when the pool has no other subject; the deep-backfill/carry-over (#41/#42) then fill from other sources.
- Detection is LLM-tagged (general — catches any over-covered figure, no keyword list to maintain). Scope: News only.

Tests: `pipeline/test_subject_cap.py` (6) + all suites green (50 total). **Backend-only — no auto-deploy**; effective next daily run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)